### PR TITLE
Added OnDeleteStrategy::Ignore and custom Error Handling including DeletionResults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,6 +655,7 @@ dependencies = [
  "quote",
  "spacetime-bindings-macro-input",
  "spacetimedb",
+ "strum",
  "syn 2.0.104",
 ]
 
@@ -660,6 +667,28 @@ dependencies = [
  "proc-macro2",
  "spacetimedb",
  "spacetimedsl",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
  "syn 2.0.104",
 ]
 

--- a/derive-input/Cargo.toml
+++ b/derive-input/Cargo.toml
@@ -32,3 +32,6 @@ spacetimedb = "1.2.0"
 
 # https://crates.io/crates/spacetime-bindings-macro-input Unofficial Input Crate for the SpacetimeDB Macro Bindings.
 spacetime-bindings-macro-input = "1.1.1"
+
+# https://crates.io/crates/strum Helpful macros for working with enums and strings
+strum = { version = "0.27", features = ["derive"] }

--- a/derive-input/src/api/dsl/column.rs
+++ b/derive-input/src/api/dsl/column.rs
@@ -24,15 +24,10 @@ pub struct SpacetimeDSLColumnMethodsForUniqueIndex {
     pub get_one_option: SpacetimeDSLMethod,
     pub update: Option<SpacetimeDSLMethod>,
     pub delete_one: SpacetimeDSLMethod,
-    pub delete_one_result_type: SpacetimeDSLDeletionResult,
 }
 
 
 pub struct SpacetimeDSLColumnMethodsForIndex {
     pub get_many: SpacetimeDSLMethod,
     pub delete_many: SpacetimeDSLMethod,
-    pub delete_many_result_type: SpacetimeDSLDeletionResult,
 }
-
-
-pub struct SpacetimeDSLDeletionResult {}

--- a/derive-input/src/api/dsl/foreign_key.rs
+++ b/derive-input/src/api/dsl/foreign_key.rs
@@ -8,20 +8,46 @@ pub struct ForeignKey {
 
 // This enum is copy+paste of the enum in the SpacetimeDSL crate (which is the public API of the DSL).
 
-#[derive(Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum OnDeleteStrategy {
-    /// Available independent from the column type.
+    /**
+     * Available independent from the column type.
+     * If a row of a table should be deleted whose primary key value is referenced in foreign keys of other tables ...
+     * ... the deletion fails.
+     */
     Error,
 
-    /// Available independent from the column type.
+    /**
+     * Available independent from the column type.
+     * If a row of a table should be deleted whose primary key value is referenced in foreign keys of other tables ...
+     * ... it's checked whether any primary key value of rows to delete is referenced in a foreign key with `OnDeleteStrategy::Error`.
+     * If true, the deletion fails and no other on delete strategy is executed.
+     * If false, the on delete strategies of all affected rows are executed.
+     */
     Delete,
 
-    // TODO: Because Option is currently not allowed on primary_key and unique/btree indices this strategy isn't used and implemented yet.
-    /// Available only for columns with type `Option<T>`.
+    /**
+     * TODO: Because Option is currently not allowed on primary_key and unique/btree indices this strategy isn't used and implemented yet.
+     * Available only for columns with type `Option<T>`.
+     * If a row of a table should be deleted whose primary key value is referenced in foreign keys of other tables ...
+     * ... the value of the foreign key column is set to `None`.
+     */
     //SetNone,
 
-    /// Available only for columns with a numeric type.
+    /**
+     * Available only for columns with a numeric type.
+     * If a row of a table should be deleted whose primary key value is referenced in foreign keys of other tables ...
+     * ... the value of the foreign key column is set to `0`.
+     */
     SetZero,
+
+    /**
+     * Available independent from the column type.
+     * If a row of a table should be deleted whose primary key value is referenced in foreign keys of other tables ...
+     * ... nothing happens, which means the referencing rows will reference a primary key value which doesn't exist anymore.
+     * The referential integrity is only enforced while creating a row or if a row is updated and the foreign key column value is changed.
+     */
+    Ignore,
 }
 
 impl quote::ToTokens for OnDeleteStrategy {
@@ -41,6 +67,7 @@ impl quote::ToTokens for OnDeleteStrategy {
                 OnDeleteStrategy::Error => "Error",
                 OnDeleteStrategy::Delete => "Delete",
                 OnDeleteStrategy::SetZero => "SetZero",
+                OnDeleteStrategy::Ignore => "Ignore",
             },
         ));
     }

--- a/derive-input/src/api/dsl/foreign_key.rs
+++ b/derive-input/src/api/dsl/foreign_key.rs
@@ -8,7 +8,7 @@ pub struct ForeignKey {
 
 // This enum is copy+paste of the enum in the SpacetimeDSL crate (which is the public API of the DSL).
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, strum::EnumIter)]
 pub enum OnDeleteStrategy {
     /**
      * Available independent from the column type.

--- a/derive-input/src/internal/column.rs
+++ b/derive-input/src/internal/column.rs
@@ -74,7 +74,6 @@ pub(in crate::internal) fn try_parse(
             &spacetimedb_table,
             &spacetimedsl_table,
             &spacetimedb_column,
-            &primary_key_column_name,
             &internal_columns,
         );
 

--- a/derive-input/src/internal/column.rs
+++ b/derive-input/src/internal/column.rs
@@ -66,6 +66,11 @@ pub(in crate::internal) fn try_parse(
         internal_columns.push(internal_column);
     }
 
+    let primary_key_column = internal_columns
+        .iter()
+        .find(|c| c.rust_field_name.to_string().eq(&"id"))
+        .expect("should have a primary key");
+
     for (rust_field, spacetimedb_column, spacetimedsl_column) in
         izip!(rust_fields, spacetimedb_columns, spacetimedsl_columns)
     {
@@ -75,6 +80,7 @@ pub(in crate::internal) fn try_parse(
             &spacetimedsl_table,
             &spacetimedb_column,
             &internal_columns,
+            primary_key_column,
         );
 
         columns.push(Column {

--- a/derive-input/src/internal/column.rs
+++ b/derive-input/src/internal/column.rs
@@ -18,7 +18,7 @@ pub(in crate::internal) fn try_parse(
     rust_struct: &RustStruct,
     mut spacetimedb_table: SpacetimeDBTable,
     spacetimedsl_table: &SpacetimeDSLTable,
-) -> syn::Result<(SpacetimeDBTable, Vec<Column>, Vec<InternalColumn>, Ident)> {
+) -> syn::Result<(SpacetimeDBTable, Vec<Column>, Vec<InternalColumn>)> {
     let primary_key_column_name = match get_primary_key_column_name(column_args) {
         Some(pk) => pk,
         None => {
@@ -85,12 +85,7 @@ pub(in crate::internal) fn try_parse(
         });
     }
 
-    Ok((
-        spacetimedb_table,
-        columns,
-        internal_columns,
-        primary_key_column_name,
-    ))
+    Ok((spacetimedb_table, columns, internal_columns))
 }
 
 pub(in crate::internal) struct InternalColumn {

--- a/derive-input/src/internal/dsl/foreign_key.rs
+++ b/derive-input/src/internal/dsl/foreign_key.rs
@@ -80,7 +80,7 @@ impl ForeignKey {
             let on_delete_strategy = on_delete_strategy.ok_or_else(|| {
             syn::Error::new_spanned(
                 &attr.meta,
-                "OnDeleteStrategy must be set in `#[foreign_key(on_delete = OnDeleteStrategy)]`, e.g. `on_delete = Delete` (or Error, SetNone or SetZero).",
+                "OnDeleteStrategy must be set in `#[foreign_key(on_delete = OnDeleteStrategy)]`, e.g. `on_delete = Delete` (or Error, SetNone, SetZero or Ignore).",
             )
         })?;
 
@@ -106,12 +106,13 @@ impl OnDeleteStrategy {
             "Delete" => Ok(OnDeleteStrategy::Delete),
             "SetNone" => Err(syn::Error::new_spanned(
                 &tokens,
-                "Because Option is currently not allowed on primary_key and unique/btree indices, `OnDeleteStrategy::SetNone` isn't implemented yet. `OnDeleteStrategy` must be one of `Error`, `Delete` or `SetZero` in `#[foreign_key(on_delete = OnDeleteStrategy)]`, e.g. `on_delete = Delete`.".to_string(),
+                "Because Option is currently not allowed on primary_key and unique/btree indices, `OnDeleteStrategy::SetNone` isn't implemented yet. `OnDeleteStrategy` must be one of `Error`, `Delete`, `SetZero` or `Ignore` in `#[foreign_key(on_delete = OnDeleteStrategy)]`, e.g. `on_delete = Delete`.".to_string(),
             )),
             "SetZero" => Ok(OnDeleteStrategy::SetZero),
+            "Ignore" => Ok(OnDeleteStrategy::Ignore),
             _ => Err(syn::Error::new_spanned(
                 &tokens,
-                "`OnDeleteStrategy` must be one of `Error`, `Delete`, `SetNone` or `SetZero` in `#[foreign_key(on_delete = OnDeleteStrategy)]`, e.g. `on_delete = Delete`.".to_string(),
+                "`OnDeleteStrategy` must be one of `Error`, `Delete`, `SetNone`, `SetZero` or `Ignore` in `#[foreign_key(on_delete = OnDeleteStrategy)]`, e.g. `on_delete = Delete`.".to_string(),
             )),
         }
     }

--- a/derive-input/src/internal/dsl/method.rs
+++ b/derive-input/src/internal/dsl/method.rs
@@ -7,7 +7,7 @@ use crate::{
         }, dsl::{
             column::{
                 SpacetimeDSLColumnMethods, SpacetimeDSLColumnMethodsForIndex,
-                SpacetimeDSLColumnMethodsForUniqueIndex, SpacetimeDSLDeletionResult,
+                SpacetimeDSLColumnMethodsForUniqueIndex,
             },
             foreign_key::OnDeleteStrategy,
             method::{SpacetimeDSLMethod, SpacetimeDSLMethodArg},
@@ -90,7 +90,6 @@ impl SpacetimeDSLColumnMethods {
                 SpacetimeDSLColumnMethods::ForIndex(SpacetimeDSLColumnMethodsForIndex {
                     get_many,
                     delete_many,
-                    delete_many_result_type: SpacetimeDSLDeletionResult {}, // TODO
                 })
             }
             true => {
@@ -128,7 +127,6 @@ impl SpacetimeDSLColumnMethods {
                     get_one_option,
                     update,
                     delete_one,
-                    delete_one_result_type: SpacetimeDSLDeletionResult {}, // TODO
                 })
             }
         };
@@ -287,7 +285,6 @@ impl SpacetimeDSLTableMethods {
                         SpacetimeDSLColumnMethodsForIndex {
                             get_many,
                             delete_many,
-                            delete_many_result_type: SpacetimeDSLDeletionResult {}, // TODO
                         },
                     ));
                 }
@@ -327,7 +324,6 @@ impl SpacetimeDSLTableMethods {
                             get_one_option,
                             update,
                             delete_one,
-                            delete_one_result_type: SpacetimeDSLDeletionResult {}, // TODO
                         },
                     ));
                 }

--- a/derive-input/src/internal/dsl/method.rs
+++ b/derive-input/src/internal/dsl/method.rs
@@ -776,7 +776,8 @@ pub(in crate::internal) fn for_method(
                     single_or_multi = "single";
                     index_documentation = format!("btree index");
                     documentation_on_column_or_columns = format!("`{column}` column");
-                    // FIXME: column_names_and_row_values
+                    column_names_and_row_values.push_str(&format!(", {column} : "));
+                    column_names_and_row_values.push_str("{} ");
                 }
                 IndexType::BTreeMultiColumn { columns } => {
                     is_multi_column_index = true;
@@ -822,7 +823,8 @@ pub(in crate::internal) fn for_method(
                     single_or_multi = "single";
                     index_documentation = format!("direct index");
                     documentation_on_column_or_columns = format!("`{column}` column");
-                    // FIXME: column_names_and_row_values
+                    column_names_and_row_values.push_str(&format!(", {column} : "));
+                    column_names_and_row_values.push_str("{} ");
                 }
             };
             column_names_and_row_values.push_str(" }}");
@@ -1253,7 +1255,7 @@ pub(in crate::internal) fn for_method(
                                 }
                             };
 
-                            let delete_many_and_return_result_impl = quote! {
+                            let delete_many_impl = quote! {
                                 let count_of_rows_to_delete = primary_key_values_of_rows_to_delete.len();
                                 let count_of_deleted_rows = #method_impl_prefix.delete(#index_name);
 
@@ -1268,7 +1270,9 @@ pub(in crate::internal) fn for_method(
                                         )
                                     );
                                 }
+                            };
 
+                            let return_result_impl = quote! {
                                 return Ok(spacetimedsl::DeletionResult {
                                     table_name: #singular_table_name_as_string.into(),
                                     one_or_multiple: #multiple,
@@ -1282,7 +1286,8 @@ pub(in crate::internal) fn for_method(
 
                                     #map_primary_key_values_of_rows_to_delete_to_deletion_result_entries
 
-                                    #delete_many_and_return_result_impl
+                                    #delete_many_impl
+                                    #return_result_impl
                                 };
                             } else {
                                 let error_strategy =
@@ -1360,7 +1365,7 @@ pub(in crate::internal) fn for_method(
                                         }
                                     };
 
-                                    // FIXME: Delete initial rows after success of error strategy
+                                    #delete_many_impl
 
                                     #delete_strategy
 
@@ -1376,7 +1381,7 @@ pub(in crate::internal) fn for_method(
 
                                     #ignore_strategy
 
-                                    #delete_many_and_return_result_impl
+                                    #return_result_impl
                                 };
                             }
                         }
@@ -1404,12 +1409,12 @@ pub(in crate::internal) fn for_method(
                                         None => {
                                             return Err(
                                                 spacetimedsl::SpacetimeDSLError::NotFoundError {
-                                                    table_name: #singular_table_name_as_string,
+                                                    table_name: #singular_table_name_as_string.into(),
                                                     column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*)
                                                 }
                                             );
                                         }
-                                    };
+                                    }
                                 };
                             }
                             false => {
@@ -1420,11 +1425,11 @@ pub(in crate::internal) fn for_method(
                                         Some(#singular_table_name) => Ok(#singular_table_name),
                                         None => return Err(
                                             spacetimedsl::SpacetimeDSLError::NotFoundError {
-                                                table_name: #singular_table_name_as_string,
+                                                table_name: #singular_table_name_as_string.into(),
                                                 column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*)
                                             }
                                         )
-                                    };
+                                    }
                                 }
                             }
                         },
@@ -1470,7 +1475,7 @@ pub(in crate::internal) fn for_method(
                                 let primary_key_value_of_a_row_to_delete = match primary_key_value_of_a_row_to_delete {
                                     None => return Err(
                                         spacetimedsl::SpacetimeDSLError::NotFoundError {
-                                            table_name: #singular_table_name_as_string,
+                                            table_name: #singular_table_name_as_string.into(),
                                             column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*)
                                         }
                                     );,
@@ -1488,7 +1493,7 @@ pub(in crate::internal) fn for_method(
                                 };
                             };
 
-                            let delete_one_and_return_result_impl = quote! {
+                            let delete_one_impl = quote! {
                                 match self
                                         .ctx()
                                         .db()
@@ -1502,14 +1507,16 @@ pub(in crate::internal) fn for_method(
                                             )
                                         );
                                     },
-                                    true => {
-                                        return Ok(spacetimedsl::DeletionResult {
-                                            table_name: #singular_table_name_as_string.into(),
-                                            one_or_multiple: #one,
-                                            entries = vec![deletion_result_entry],
-                                        });
-                                    },
+                                    true => {},
                                 };
+                            };
+
+                            let return_result_impl = quote! {
+                                return Ok(spacetimedsl::DeletionResult {
+                                    table_name: #singular_table_name_as_string.into(),
+                                    one_or_multiple: #one,
+                                    entries = vec![deletion_result_entry],
+                                });
                             };
 
                             if spacetimedsl_table.referencing_tables.is_empty() {
@@ -1518,7 +1525,8 @@ pub(in crate::internal) fn for_method(
 
                                     #map_primary_key_value_of_a_row_to_delete_to_deletion_result_entry
 
-                                    #delete_one_and_return_result_impl
+                                    #delete_one_impl
+                                    #return_result_impl
                                 };
                             } else {
                                 let error_strategy =
@@ -1596,7 +1604,7 @@ pub(in crate::internal) fn for_method(
                                         }
                                     };
 
-                                    // FIXME: Delete initial row after success of error strategy
+                                    #delete_one_impl
 
                                     #delete_strategy
 
@@ -1612,7 +1620,7 @@ pub(in crate::internal) fn for_method(
 
                                     #ignore_strategy
 
-                                    #delete_one_and_return_result_impl
+                                    #return_result_impl
                                 };
                             }
                         }
@@ -1675,7 +1683,7 @@ fn get_referenced_table_function_call_for_dsl_method(
                 match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), #on_delete_strategy, primary_key_values_of_rows_to_delete) {
                     Err(child_entries_by_primary_key_value_of_a_row_to_delete) => {
                         for (primary_key_value_of_a_row_to_delete, child_entries) in child_entries_by_primary_key_value_of_a_row_to_delete {
-                            deletion_result_entries.get_mut(primary_key_value_of_a_row_to_delete).child_entries.append(child_entries);
+                            deletion_result_entries.get_mut(primary_key_value_of_a_row_to_delete).unwrap().child_entries.append(child_entries);
                         }
 
                         error = Some(spacetimedsl::DeletionResult {
@@ -1686,7 +1694,7 @@ fn get_referenced_table_function_call_for_dsl_method(
                     },
                     Ok(child_entries_by_primary_key_value_of_a_row_to_delete) => {
                         for (primary_key_value_of_a_row_to_delete, child_entries) in child_entries_by_primary_key_value_of_a_row_to_delete {
-                            deletion_result_entries.get_mut(primary_key_value_of_a_row_to_delete).child_entries.append(child_entries);
+                            deletion_result_entries.get_mut(primary_key_value_of_a_row_to_delete).unwrap().child_entries.append(child_entries);
                         }
                     }
                 };
@@ -1768,7 +1776,7 @@ fn reference_integrity_checks_on_create_or_update(
                             return Err(
                                 spacetimedsl::SpacetimeDSLError::ReferenceIntegrityViolation(
                                     spacetimedsl::ReferenceIntegrityViolationError::OnCreateOrUpdate {
-                                        table_name: #referencing_table_name_as_string,
+                                        table_name: #referencing_table_name_as_string.into(),
                                         create_or_update: spacetimedsl::Action::Create,
                                         column_names_and_row_values: format!(#column_names_and_row_values, #referencing_table_name.#referencing_table_column_getter_name())
                                     }
@@ -1788,7 +1796,7 @@ fn reference_integrity_checks_on_create_or_update(
                             None => {
                                 return Err(
                                     spacetimedsl::SpacetimeDSLError::NotFoundError {
-                                        table_name: #referencing_table_name_as_string,
+                                        table_name: #referencing_table_name_as_string.into(),
                                         column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*)
                                     }
                                 );
@@ -1801,7 +1809,7 @@ fn reference_integrity_checks_on_create_or_update(
                             None => return Err(
                                 spacetimedsl::SpacetimeDSLError::ReferenceIntegrityViolation(
                                     spacetimedsl::ReferenceIntegrityViolationError::OnCreateOrUpdate {
-                                        table_name: #referencing_table_name_as_string,
+                                        table_name: #referencing_table_name_as_string.into(),
                                         create_or_update: spacetimedsl::Action::Update,
                                         column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*)
                                     }
@@ -2015,13 +2023,13 @@ fn for_referenced_by(
                 is_mut: false,
                 arg_name: arg_name.clone(),
                 arg_type: quote! {
-                    Vec<&#primary_key_column_type>
+                    &'a Vec<#primary_key_column_type>
                 },
             });
             return_type = quote! {
                 Result<
-                    std::collections::HashMap<&#primary_key_column_type, Vec<spacetimedsl::DeletionResultEntry>>,
-                    std::collections::HashMap<&#primary_key_column_type, Vec<spacetimedsl::DeletionResultEntry>>
+                    std::collections::HashMap<&'a #primary_key_column_type, Vec<spacetimedsl::DeletionResultEntry>>,
+                    std::collections::HashMap<&'a #primary_key_column_type, Vec<spacetimedsl::DeletionResultEntry>>
                 >
             };
         }
@@ -2076,13 +2084,13 @@ fn for_referenced_by(
                         use #referencing_table_path::#referencing_table_trait_name;
 
                         match spacetimedsl::internal::DSLInternals::#referencing_table_function_name(ctx, &strategy, #arg_name) {
-                            Err(child_entries) => {
-                                entries.append(child_entries);
+                            Err(mut child_entries) => {
+                                entries.append(&mut child_entries);
 
                                 error = true;
                             },
-                            Ok(child_entries) => {
-                                entries.append(child_entries);
+                            Ok(mut child_entries) => {
+                                entries.append(&mut child_entries);
                             },
                         };
                     }
@@ -2093,15 +2101,15 @@ fn for_referenced_by(
 
                         match spacetimedsl::internal::DSLInternals::#referencing_table_function_name(ctx, &strategy, #arg_name) {
                             Err(child_entries_by_primary_key_value_of_a_row_to_delete) => {
-                                for (primary_key_value_of_a_row_to_delete, child_entries) in child_entries_by_primary_key_value_of_a_row_to_delete {
-                                    entries.get_mut(primary_key_value_of_a_row_to_delete).child_entries.append(child_entries);
+                                for (primary_key_value_of_a_row_to_delete, mut child_entries) in child_entries_by_primary_key_value_of_a_row_to_delete {
+                                    entries.get_mut(&primary_key_value_of_a_row_to_delete).unwrap().append(&mut child_entries);
                                 }
 
                                 error = true;
                             },
                             Ok(child_entries_by_primary_key_value_of_a_row_to_delete) => {
                                 for (primary_key_value_of_a_row_to_delete, child_entries) in child_entries_by_primary_key_value_of_a_row_to_delete {
-                                    entries.get_mut(primary_key_value_of_a_row_to_delete).child_entries.append(child_entries);
+                                    entries.get_mut(&primary_key_value_of_a_row_to_delete).unwrap().append(&mut child_entries);
                                 }
                             },
                         };
@@ -2144,13 +2152,6 @@ fn for_foreign_key(
     referenced_table_name: &syn::Ident,
     columns_with_foreign_key: &Vec<&&Column>,
 ) -> SpacetimeDSLMethod {
-    let primary_key_column_type = &columns
-        .iter()
-        .find(|c| c.rust_field.name.to_string().eq(&"id"))
-        .expect("should have a primary key")
-        .rust_field
-        .type_name_or_path;
-
     let first_foreign_key_column = columns_with_foreign_key
         .first()
         .expect("there should be a column with foreign key");
@@ -2248,7 +2249,7 @@ fn for_foreign_key(
             function_args.push(SpacetimeDSLMethodArg {
                 is_mut: false,
                 arg_name: arg_name.clone(),
-                arg_type: quote! { &#primary_key_column_type },
+                arg_type: quote! { &#referenced_table_primary_key_column_type },
             });
             return_type = quote! {
                 Result<Vec<spacetimedsl::DeletionResultEntry>, Vec<spacetimedsl::DeletionResultEntry>>
@@ -2263,13 +2264,13 @@ fn for_foreign_key(
                 is_mut: false,
                 arg_name: arg_name.clone(),
                 arg_type: quote! {
-                    Vec<&#primary_key_column_type>
+                    &Vec<#referenced_table_primary_key_column_type>
                 },
             });
             return_type = quote! {
                 Result<
-                    std::collections::HashMap<&#primary_key_column_type, Vec<spacetimedsl::DeletionResultEntry>>,
-                    std::collections::HashMap<&#primary_key_column_type, Vec<spacetimedsl::DeletionResultEntry>>
+                    std::collections::HashMap<&#referenced_table_primary_key_column_type, Vec<spacetimedsl::DeletionResultEntry>>,
+                    std::collections::HashMap<&#referenced_table_primary_key_column_type, Vec<spacetimedsl::DeletionResultEntry>>
                 >
             };
         }
@@ -2324,6 +2325,7 @@ fn for_foreign_key(
         .collect_vec();
 
     let function_impl = quote! {
+        use spacetimedsl::itertools::Itertools;
         #create_data_structure_for_child_entries
 
         let mut error = false;
@@ -2414,7 +2416,7 @@ fn get_on_delete_strategy_implementation(
             }
             OneOrMultiple::Multiple => {
                 create_entry_and_add_it_to_entries = quote! {
-                    entries.get_mut(primary_key_value_of_a_row_of_another_table_to_delete).push(#create_entry);
+                    entries.get_mut(primary_key_value_of_a_row_of_another_table_to_delete).unwrap().push(#create_entry);
                 };
             }
         };
@@ -2454,14 +2456,12 @@ fn get_on_delete_strategy_implementation(
                         let error_strategy =
                             get_referenced_table_function_call_for_strategy_implementation(
                                 singular_table_name,
-                                &singular_table_name_as_string,
                                 OnDeleteStrategy::Error,
                             );
 
                         let delete_strategy =
                             get_referenced_table_function_call_for_strategy_implementation(
                                 singular_table_name,
-                                &singular_table_name_as_string,
                                 OnDeleteStrategy::Delete,
                             );
 
@@ -2476,14 +2476,12 @@ fn get_on_delete_strategy_implementation(
                         let set_zero_strategy =
                             get_referenced_table_function_call_for_strategy_implementation(
                                 singular_table_name,
-                                &singular_table_name_as_string,
                                 OnDeleteStrategy::SetZero,
                             );
 
                         let ignore_strategy =
                             get_referenced_table_function_call_for_strategy_implementation(
                                 singular_table_name,
-                                &singular_table_name_as_string,
                                 OnDeleteStrategy::Ignore,
                             );
 
@@ -2506,8 +2504,8 @@ fn get_on_delete_strategy_implementation(
                         };
 
                         strategy_for_each_row = quote! {
-                            if !child_entries_by_primary_key_value_of_row_to_delete.contains(&row.id) {
-                                primary_key_values_of_rows_to_delete_by_primary_key_value_of_a_row_of_another_table_to_delete.get_mut(primary_key_value_of_a_row_of_another_table_to_delete).push(&row.id);
+                            if !child_entries_by_primary_key_value_of_row_to_delete.contains_key(&row.id) {
+                                primary_key_values_of_rows_to_delete_by_primary_key_value_of_a_row_of_another_table_to_delete.get_mut(primary_key_value_of_a_row_of_another_table_to_delete).unwrap().push(&row.id);
                                 child_entries_by_primary_key_value_of_row_to_delete.insert(&row.id, vec![]);
                             }
                         };
@@ -2544,7 +2542,11 @@ fn get_on_delete_strategy_implementation(
                                 }
                             };
 
-                            // FIXME: Delete initial rows after success of error strategy
+                            for id in primary_key_values_of_rows_to_delete {
+                                #spacetimedb_call_prefix
+                                    .id()
+                                    .delete(id);
+                            }
 
                             #special_error_handler
 
@@ -2661,25 +2663,23 @@ fn strategy_by_row(
 
 fn get_referenced_table_function_call_for_strategy_implementation(
     singular_table_name: &Ident,
-    singular_table_name_as_string: &String,
     on_delete_strategy: OnDeleteStrategy,
 ) -> TokenStream {
     let referenced_table_function_name =
         get_referenced_table_function_name(&OneOrMultiple::Multiple, &singular_table_name);
 
-    // std::collections::HashMap<&#primary_key_column_type, Vec<spacetimedsl::DeletionResultEntry>>
     quote! {
-        match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), #on_delete_strategy, primary_key_values_of_rows_to_delete) {
+        match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(ctx, #on_delete_strategy, primary_key_values_of_rows_to_delete) {
             Err(child_entries_by_primary_key_value_of_a_row_to_delete) => {
                 error = true;
 
                 for (primary_key_value_of_a_row_to_delete, child_entries) in child_entries_by_primary_key_value_of_a_row_to_delete {
-                    child_entries_by_primary_key_value_of_row_to_delete.get_mut(primary_key_value_of_a_row_to_delete).append(child_entries);
+                    child_entries_by_primary_key_value_of_row_to_delete.get_mut(primary_key_value_of_a_row_to_delete).unwrap().append(child_entries);
                 }
             },
             Ok(child_entries_by_primary_key_value_of_a_row_to_delete) => {
                 for (primary_key_value_of_a_row_to_delete, child_entries) in child_entries_by_primary_key_value_of_a_row_to_delete {
-                    child_entries_by_primary_key_value_of_row_to_delete.get_mut(primary_key_value_of_a_row_to_delete).append(child_entries);
+                    child_entries_by_primary_key_value_of_row_to_delete.get_mut(primary_key_value_of_a_row_to_delete).unwrap().append(child_entries);
                 }
             }
         };

--- a/derive-input/src/internal/dsl/method.rs
+++ b/derive-input/src/internal/dsl/method.rs
@@ -1285,94 +1285,88 @@ pub(in crate::internal) fn for_method(
                                     #return_result_impl
                                 };
                             } else {
+                                let on_error_handler = quote! {
+                                    let error = spacetimedsl::DeletionResult {
+                                        table_name: #singular_table_name_as_string.into(),
+                                        one_or_multiple: #multiple,
+                                        entries: deletion_result_entries.into_values().collect_vec(),
+                                    };
+
+                                    return Err(
+                                        spacetimedsl::SpacetimeDSLError::Error(
+                                            format!("Delete Many Error: An unknown error occurred after changing the database state! If the reducer running this doesn't return an error, the state changes are persisted and you have problems now! Here is the deletion result: {error}")
+                                        )
+                                    );
+                                };
+
                                 let error_strategy =
                                     get_referenced_table_function_call_for_dsl_method(
                                         singular_table_name,
-                                        &singular_table_name_as_string,
                                         OnDeleteStrategy::Error,
                                         OneOrMultiple::Multiple,
+                                        &quote! {
+                                            let error = spacetimedsl::DeletionResult {
+                                                table_name: #singular_table_name_as_string.into(),
+                                                one_or_multiple: #multiple,
+                                                entries: deletion_result_entries.into_values().collect_vec(),
+                                            };
+
+                                            return Err(
+                                                spacetimedsl::SpacetimeDSLError::ReferenceIntegrityViolation(
+                                                    spacetimedsl::ReferenceIntegrityViolationError::OnDelete(error)
+                                                )
+                                            );
+                                        },
                                     );
 
                                 let delete_strategy =
                                     get_referenced_table_function_call_for_dsl_method(
                                         singular_table_name,
-                                        &singular_table_name_as_string,
                                         OnDeleteStrategy::Delete,
                                         OneOrMultiple::Multiple,
+                                        &on_error_handler,
                                     );
 
                                 /* TODO
-                                                               let set_none_strategy =
-                                                                   get_referenced_table_function_call_for_dsl_method(
-                                                                       singular_table_name,
-                                                                       &singular_table_name_as_string,
-                                                                       OnDeleteStrategy::SetNone,
-                                                                       OneOrMultiple::Multiple,
-                                                                   );
+                                let set_none_strategy =
+                                    get_referenced_table_function_call_for_dsl_method(
+                                        singular_table_name,
+                                        OnDeleteStrategy::SetNone,
+                                        OneOrMultiple::Multiple,
+                                        &on_error_handler,
+                                    );
                                 */
 
                                 let set_zero_strategy =
                                     get_referenced_table_function_call_for_dsl_method(
                                         singular_table_name,
-                                        &singular_table_name_as_string,
                                         OnDeleteStrategy::SetZero,
                                         OneOrMultiple::Multiple,
+                                        &on_error_handler,
                                     );
 
                                 let ignore_strategy =
                                     get_referenced_table_function_call_for_dsl_method(
                                         singular_table_name,
-                                        &singular_table_name_as_string,
                                         OnDeleteStrategy::Ignore,
                                         OneOrMultiple::Multiple,
+                                        &on_error_handler,
                                     );
-
-                                let special_error_handler = quote! {
-                                    match error {
-                                        None => {},
-                                        Some(error) => {
-                                            return Err(
-                                                spacetimedsl::SpacetimeDSLError::Error(
-                                                    format!("Delete Many Error: An unknown error occurred after changing the database state! If the reducer running this doesn't return an error, the state changes are persisted and you have problems now! Here is the deletion result: {error}")
-                                                )
-                                            );
-                                        }
-                                    };
-                                };
 
                                 method_impl = quote! {
                                     #impl_until_return_ok_on_is_empty
 
                                     #map_primary_key_values_of_rows_to_delete_to_deletion_result_entries
 
-                                    let mut error: Option<spacetimedsl::DeletionResult> = None;
-
                                     #error_strategy
-
-                                    match error {
-                                        None => {},
-                                        Some(error) => {
-                                            return Err(
-                                                spacetimedsl::SpacetimeDSLError::ReferenceIntegrityViolation(
-                                                    spacetimedsl::ReferenceIntegrityViolationError::OnDelete(error)
-                                                )
-                                            );
-                                        }
-                                    };
 
                                     #delete_many_impl
 
                                     #delete_strategy
 
-                                    #special_error_handler
-
                                     //TODO #set_none_strategy
 
-                                    // TODO #special_error_handler
-
                                     #set_zero_strategy
-
-                                    #special_error_handler
 
                                     #ignore_strategy
 
@@ -1443,8 +1437,6 @@ pub(in crate::internal) fn for_method(
                                             );
 
                                         quote! {
-                                            use spacetimedsl::itertools::Itertools;
-
                                             let #index_name = (#(#row_value_getters),*);
 
                                             let mut #field_name_for_found_value: Option<#struct_name> = None;
@@ -1472,10 +1464,10 @@ pub(in crate::internal) fn for_method(
                                     None => return Err(
                                         spacetimedsl::SpacetimeDSLError::NotFoundError {
                                             table_name: #singular_table_name_as_string.into(),
-                                            column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*).into()
+                                            column_names_and_row_values: format!(#column_names_and_row_values, &#index_name).into()
                                         }
-                                    );,
-                                    Some(primary_key_value_of_a_row_to_delete) => primary_key_value_of_a_row_to_delete,
+                                    ),
+                                    Some(primary_key_value_of_a_row_to_delete) => primary_key_value_of_a_row_to_delete.id,
                                 };
                             };
 
@@ -1511,7 +1503,7 @@ pub(in crate::internal) fn for_method(
                                 return Ok(spacetimedsl::DeletionResult {
                                     table_name: #singular_table_name_as_string.into(),
                                     one_or_multiple: #one,
-                                    entries = vec![deletion_result_entry],
+                                    entries: vec![deletion_result_entry],
                                 });
                             };
 
@@ -1525,94 +1517,88 @@ pub(in crate::internal) fn for_method(
                                     #return_result_impl
                                 };
                             } else {
+                                let on_error_handler = quote! {
+                                    let error = spacetimedsl::DeletionResult {
+                                        table_name: #singular_table_name_as_string.into(),
+                                        one_or_multiple: #one,
+                                        entries: vec![deletion_result_entry],
+                                    };
+
+                                    return Err(
+                                        spacetimedsl::SpacetimeDSLError::Error(
+                                            format!("Delete One Error: An unknown error occurred after changing the database state! If the reducer running this doesn't return an error, the state changes are persisted and you have problems now! Here is the deletion result: {error}")
+                                        )
+                                    );
+                                };
+
                                 let error_strategy =
                                     get_referenced_table_function_call_for_dsl_method(
                                         singular_table_name,
-                                        &singular_table_name_as_string,
                                         OnDeleteStrategy::Error,
                                         OneOrMultiple::One,
+                                        &quote! {
+                                            let error = spacetimedsl::DeletionResult {
+                                                table_name: #singular_table_name_as_string.into(),
+                                                one_or_multiple: #one,
+                                                entries: vec![deletion_result_entry],
+                                            };
+
+                                            return Err(
+                                                spacetimedsl::SpacetimeDSLError::ReferenceIntegrityViolation(
+                                                    spacetimedsl::ReferenceIntegrityViolationError::OnDelete(error)
+                                                )
+                                            );
+                                        },
                                     );
 
                                 let delete_strategy =
                                     get_referenced_table_function_call_for_dsl_method(
                                         singular_table_name,
-                                        &singular_table_name_as_string,
                                         OnDeleteStrategy::Delete,
                                         OneOrMultiple::One,
+                                        &on_error_handler,
                                     );
 
                                 /* TODO
-                                                               let set_none_strategy =
-                                                                   get_referenced_table_function_call_for_dsl_method(
-                                                                       singular_table_name,
-                                                                       &singular_table_name_as_string,
-                                                                       OnDeleteStrategy::SetNone,
-                                                                       OneOrMultiple::One,
-                                                                   );
+                                let set_none_strategy =
+                                    get_referenced_table_function_call_for_dsl_method(
+                                        singular_table_name,
+                                        OnDeleteStrategy::SetNone,
+                                        OneOrMultiple::One,
+                                        &on_error_handler,
+                                    );
                                 */
 
                                 let set_zero_strategy =
                                     get_referenced_table_function_call_for_dsl_method(
                                         singular_table_name,
-                                        &singular_table_name_as_string,
                                         OnDeleteStrategy::SetZero,
                                         OneOrMultiple::One,
+                                        &on_error_handler,
                                     );
 
                                 let ignore_strategy =
                                     get_referenced_table_function_call_for_dsl_method(
                                         singular_table_name,
-                                        &singular_table_name_as_string,
                                         OnDeleteStrategy::Ignore,
                                         OneOrMultiple::One,
+                                        &on_error_handler,
                                     );
-
-                                let special_error_handler = quote! {
-                                    match error {
-                                        None => {},
-                                        Some(error) => {
-                                            return Err(
-                                                spacetimedsl::SpacetimeDSLError::Error(
-                                                    format!("Delete One Error: An unknown error occurred after changing the database state! If the reducer running this doesn't return an error, the state changes are persisted and you have problems now! Here is the deletion result: {error}")
-                                                )
-                                            );
-                                        }
-                                    };
-                                };
 
                                 method_impl = quote! {
                                     #impl_until_return_err_on_is_none
 
                                     #map_primary_key_value_of_a_row_to_delete_to_deletion_result_entry
 
-                                    let mut error: Option<spacetimedsl::DeletionResult> = None;
-
                                     #error_strategy
-
-                                    match error {
-                                        None => {},
-                                        Some(error) => {
-                                            return Err(
-                                                spacetimedsl::SpacetimeDSLError::ReferenceIntegrityViolation(
-                                                    spacetimedsl::ReferenceIntegrityViolationError::OnDelete(error)
-                                                )
-                                            );
-                                        }
-                                    };
 
                                     #delete_one_impl
 
                                     #delete_strategy
 
-                                    #special_error_handler
-
                                     //TODO #set_none_strategy
 
-                                    // TODO #special_error_handler
-
                                     #set_zero_strategy
-
-                                    #special_error_handler
 
                                     #ignore_strategy
 
@@ -1645,9 +1631,9 @@ pub(in crate::internal) fn for_method(
 
 fn get_referenced_table_function_call_for_dsl_method(
     singular_table_name: &Ident,
-    singular_table_name_as_string: &String,
     on_delete_strategy: OnDeleteStrategy,
     one_or_multiple: OneOrMultiple,
+    on_error_handler: &TokenStream,
 ) -> TokenStream {
     match one_or_multiple {
         OneOrMultiple::One => {
@@ -1655,15 +1641,11 @@ fn get_referenced_table_function_call_for_dsl_method(
                 get_referenced_table_function_name(&OneOrMultiple::One, &singular_table_name);
 
             quote! {
-                match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), #on_delete_strategy, primary_key_value_of_a_row_to_delete) {
+                match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), #on_delete_strategy, &primary_key_value_of_a_row_to_delete) {
                     Err(mut child_entries) => {
                         deletion_result_entry.child_entries.append(&mut child_entries);
 
-                        error = Some(spacetimedsl::DeletionResult {
-                            table_name: #singular_table_name_as_string.into(),
-                            one_or_multiple: #one_or_multiple,
-                            entries: vec![deletion_result_entry],
-                        });
+                        #on_error_handler
                     },
                     Ok(mut child_entries) => {
                         deletion_result_entry.child_entries.append(&mut child_entries);
@@ -1682,11 +1664,7 @@ fn get_referenced_table_function_call_for_dsl_method(
                             deletion_result_entries.get_mut(primary_key_value_of_a_row_to_delete).unwrap().child_entries.append(&mut child_entries);
                         }
 
-                        error = Some(spacetimedsl::DeletionResult {
-                            table_name: #singular_table_name_as_string.into(),
-                            one_or_multiple: #one_or_multiple,
-                            entries: deletion_result_entries.into_values().collect_vec(),
-                        });
+                        #on_error_handler
                     },
                     Ok(child_entries_by_primary_key_value_of_a_row_to_delete) => {
                         for (primary_key_value_of_a_row_to_delete, mut child_entries) in child_entries_by_primary_key_value_of_a_row_to_delete {

--- a/derive-input/src/internal/dsl/method.rs
+++ b/derive-input/src/internal/dsl/method.rs
@@ -118,6 +118,7 @@ impl SpacetimeDSLColumnMethods {
         spacetimedsl_table: &SpacetimeDSLTable,
         spacetimedb_column: &SpacetimeDBColumn,
         internal_columns: &Vec<InternalColumn>,
+        primary_key_column: &InternalColumn,
     ) -> Option<SpacetimeDSLColumnMethods> {
         let index = match &spacetimedb_column.single_column_index {
             None => {
@@ -134,6 +135,7 @@ impl SpacetimeDSLColumnMethods {
                     spacetimedb_table,
                     spacetimedsl_table,
                     internal_columns,
+                    primary_key_column,
                 );
 
                 let delete_many = for_method(
@@ -142,6 +144,7 @@ impl SpacetimeDSLColumnMethods {
                     spacetimedb_table,
                     spacetimedsl_table,
                     internal_columns,
+                    primary_key_column,
                 );
 
                 SpacetimeDSLColumnMethods::ForIndex(SpacetimeDSLColumnMethodsForIndex {
@@ -156,6 +159,7 @@ impl SpacetimeDSLColumnMethods {
                     spacetimedb_table,
                     spacetimedsl_table,
                     internal_columns,
+                    primary_key_column,
                 );
 
                 let update = match spacetimedsl_table.is_mutable {
@@ -166,6 +170,7 @@ impl SpacetimeDSLColumnMethods {
                         spacetimedb_table,
                         spacetimedsl_table,
                         internal_columns,
+                        primary_key_column,
                     )),
                 };
 
@@ -175,6 +180,7 @@ impl SpacetimeDSLColumnMethods {
                     spacetimedb_table,
                     spacetimedsl_table,
                     internal_columns,
+                    primary_key_column,
                 );
 
                 SpacetimeDSLColumnMethods::ForUniqueIndex(SpacetimeDSLColumnMethodsForUniqueIndex {
@@ -196,6 +202,7 @@ impl SpacetimeDSLTableMethods {
         spacetimedsl_table: &SpacetimeDSLTable,
         columns: &Vec<Column>,
         internal_columns: &Vec<InternalColumn>,
+        primary_key_column: &InternalColumn,
     ) -> syn::Result<SpacetimeDSLTableMethods> {
         let create = for_method(
             DSLMethod::Create,
@@ -203,6 +210,7 @@ impl SpacetimeDSLTableMethods {
             spacetimedb_table,
             spacetimedsl_table,
             internal_columns,
+            primary_key_column,
         );
 
         let get_all = for_method(
@@ -211,6 +219,7 @@ impl SpacetimeDSLTableMethods {
             spacetimedb_table,
             spacetimedsl_table,
             internal_columns,
+            primary_key_column,
         );
 
         let get_count = for_method(
@@ -219,6 +228,7 @@ impl SpacetimeDSLTableMethods {
             spacetimedb_table,
             spacetimedsl_table,
             internal_columns,
+            primary_key_column,
         );
 
         let execute_on_delete_strategies_of_referencing_tables_after_one_row_of_this_table_was_deleted;
@@ -287,6 +297,7 @@ impl SpacetimeDSLTableMethods {
                             spacetimedb_table,
                             referenced_table_name,
                             &columns_with_foreign_key,
+                            &primary_key_column,
                         )
                     );
                     execute_on_delete_strategies_of_this_table_after_multiple_rows_of_the_referenced_table_were_deleted.push(
@@ -296,6 +307,7 @@ impl SpacetimeDSLTableMethods {
                             spacetimedb_table,
                             referenced_table_name,
                             &columns_with_foreign_key,
+                            &primary_key_column,
                         )
                     );
                 });
@@ -312,6 +324,7 @@ impl SpacetimeDSLTableMethods {
                         spacetimedb_table,
                         spacetimedsl_table,
                         internal_columns,
+                        &primary_key_column,
                     );
                     let delete_many = for_method(
                         DSLMethod::DeleteMany(multi_column_index),
@@ -319,6 +332,7 @@ impl SpacetimeDSLTableMethods {
                         spacetimedb_table,
                         spacetimedsl_table,
                         internal_columns,
+                        &primary_key_column,
                     );
 
                     multi_column_indices.push(SpacetimeDSLColumnMethods::ForIndex(
@@ -335,6 +349,7 @@ impl SpacetimeDSLTableMethods {
                         spacetimedb_table,
                         spacetimedsl_table,
                         internal_columns,
+                        &primary_key_column,
                     );
 
                     let update = match spacetimedsl_table.is_mutable {
@@ -345,6 +360,7 @@ impl SpacetimeDSLTableMethods {
                             spacetimedb_table,
                             spacetimedsl_table,
                             internal_columns,
+                            &primary_key_column,
                         )),
                     };
 
@@ -354,6 +370,7 @@ impl SpacetimeDSLTableMethods {
                         spacetimedb_table,
                         spacetimedsl_table,
                         internal_columns,
+                        &primary_key_column,
                     );
 
                     multi_column_indices.push(SpacetimeDSLColumnMethods::ForUniqueIndex(
@@ -568,6 +585,7 @@ pub(in crate::internal) fn for_method(
     spacetimedb_table: &SpacetimeDBTable,
     spacetimedsl_table: &SpacetimeDSLTable,
     internal_columns: &Vec<InternalColumn>,
+    primary_key_column: &InternalColumn,
 ) -> SpacetimeDSLMethod {
     let struct_name = &rust_struct.name;
     let singular_table_name = &spacetimedb_table.singular_name;
@@ -575,6 +593,8 @@ pub(in crate::internal) fn for_method(
     let singular_table_name_pascal_case =
         RenameRule::PascalCase.apply_to_field(singular_table_name.to_string());
     let plural_table_name = &spacetimedsl_table.plural_name;
+
+    let primary_key_column_type = &primary_key_column.rust_field_type_name_or_path;
 
     let one = OneOrMultiple::One;
     let multiple = OneOrMultiple::Multiple;
@@ -1219,14 +1239,6 @@ pub(in crate::internal) fn for_method(
                                 },
                             };
 
-                            let primary_key_column = internal_columns
-                                .iter()
-                                .find(|c| c.rust_field_name.to_string().eq(&"id"))
-                                .expect("should have a primary key");
-
-                            let primary_key_column_type =
-                                &primary_key_column.rust_field_type_name_or_path;
-
                             let impl_until_return_ok_on_is_empty = quote! {
                                 use spacetimedsl::itertools::Itertools;
 
@@ -1248,6 +1260,19 @@ pub(in crate::internal) fn for_method(
                                 }
                             };
 
+                            let wrapper_type_struct_name_or_path = match primary_key_column
+                                .spacetimedsl_column_wrapper_type
+                                .as_ref()
+                                .unwrap()
+                            {
+                                WrapperType::Wrap(wrap) => {
+                                    wrap.wrapper_struct_name.to_token_stream()
+                                }
+                                WrapperType::Wrapped(wrapped) => {
+                                    wrapped.wrapper_struct_name_or_path.to_token_stream()
+                                }
+                            };
+
                             let map_primary_key_values_of_rows_to_delete_to_deletion_result_entries = quote! {
                                 let mut deletion_result_entries = std::collections::HashMap::new();
 
@@ -1258,7 +1283,7 @@ pub(in crate::internal) fn for_method(
                                             table_name: #singular_table_name_as_string.into(),
                                             column_name: "id".into(),
                                             strategy: spacetimedsl::OnDeleteStrategy::Delete,
-                                            row_value: format!("{primary_key_value_of_a_row_to_delete}").into(),
+                                            row_value: format!("{}", #wrapper_type_struct_name_or_path::new(primary_key_value_of_a_row_to_delete.clone())).into(),
                                             child_entries: vec![],
                                         }
                                     );
@@ -1517,12 +1542,25 @@ pub(in crate::internal) fn for_method(
                                 #get_primary_key_value_of_row_to_delete
                             };
 
+                            let wrapper_type_struct_name_or_path = match primary_key_column
+                                .spacetimedsl_column_wrapper_type
+                                .as_ref()
+                                .unwrap()
+                            {
+                                WrapperType::Wrap(wrap) => {
+                                    wrap.wrapper_struct_name.to_token_stream()
+                                }
+                                WrapperType::Wrapped(wrapped) => {
+                                    wrapped.wrapper_struct_name_or_path.to_token_stream()
+                                }
+                            };
+
                             let map_primary_key_value_of_a_row_to_delete_to_deletion_result_entry = quote! {
                                 let mut deletion_result_entry = spacetimedsl::DeletionResultEntry {
                                     table_name: #singular_table_name_as_string.into(),
                                     column_name: "id".into(),
                                     strategy: spacetimedsl::OnDeleteStrategy::Delete,
-                                    row_value: format!("{primary_key_value_of_a_row_to_delete}").into(),
+                                    row_value: format!("{}", #wrapper_type_struct_name_or_path::new(primary_key_value_of_a_row_to_delete.clone())).into(),
                                     child_entries: vec![],
                                 };
                             };
@@ -2212,6 +2250,7 @@ fn for_foreign_key(
     spacetimedb_table: &SpacetimeDBTable,
     referenced_table_name: &syn::Ident,
     columns_with_foreign_key: &Vec<&&Column>,
+    primary_key_column: &InternalColumn,
 ) -> SpacetimeDSLMethod {
     let first_foreign_key_column = columns_with_foreign_key
         .first()
@@ -2370,6 +2409,7 @@ fn for_foreign_key(
                 on_delete_strategy,
                 columns_by_on_delete_strategy,
                 &one_or_multiple,
+                primary_key_column,
             ),
         );
     }
@@ -2418,6 +2458,7 @@ fn get_on_delete_strategy_implementation(
     on_delete_strategy: &OnDeleteStrategy,
     columns_by_on_delete_strategy: Vec<&&&Column>,
     one_or_multiple: &OneOrMultiple,
+    primary_key_column: &InternalColumn,
 ) -> TokenStream {
     let spacetimedb_call_prefix = quote! {
         ctx
@@ -2455,12 +2496,21 @@ fn get_on_delete_strategy_implementation(
             }
         };
 
+        let wrapper_type_struct_name_or_path = match primary_key_column
+            .spacetimedsl_column_wrapper_type
+            .as_ref()
+            .unwrap()
+        {
+            WrapperType::Wrap(wrap) => wrap.wrapper_struct_name.to_token_stream(),
+            WrapperType::Wrapped(wrapped) => wrapped.wrapper_struct_name_or_path.to_token_stream(),
+        };
+
         let create_entry = quote! {
             spacetimedsl::DeletionResultEntry {
                 table_name: #singular_table_name_as_string.into(),
                 column_name: #column_name_as_string.into(),
                 strategy: #on_delete_strategy,
-                row_value: format!("{}", id).into(),
+                row_value: format!("{}", #wrapper_type_struct_name_or_path::new(id.clone())).into(),
                 child_entries,
             }
         };

--- a/derive-input/src/internal/dsl/method.rs
+++ b/derive-input/src/internal/dsl/method.rs
@@ -1212,6 +1212,14 @@ pub(in crate::internal) fn for_method(
                                 },
                             };
 
+                            let primary_key_column = internal_columns
+                                .iter()
+                                .find(|c| c.rust_field_name.to_string().eq(&"id"))
+                                .expect("should have a primary key");
+
+                            let primary_key_column_type =
+                                &primary_key_column.rust_field_type_name_or_path;
+
                             let impl_until_return_ok_on_is_empty = quote! {
                                 use spacetimedsl::itertools::Itertools;
 
@@ -1219,7 +1227,7 @@ pub(in crate::internal) fn for_method(
 
                                 #let_index_name
 
-                                let primary_key_values_of_rows_to_delete = #method_impl_prefix
+                                let primary_key_values_of_rows_to_delete: Vec<#primary_key_column_type> = #method_impl_prefix
                                     .filter(#index_name)
                                     .map(|row| row.id)
                                     .collect();
@@ -1250,8 +1258,11 @@ pub(in crate::internal) fn for_method(
                                 }
                             };
 
-                            let delete_many_impl = quote! {
-                                let count_of_rows_to_delete = primary_key_values_of_rows_to_delete.len();
+                                let delete_many_impl = quote! {let count_of_rows_to_delete: u64 = primary_key_values_of_rows_to_delete
+                                    .len()
+                                    .try_into()
+                                    .unwrap_or(u64::MAX);
+
                                 let count_of_deleted_rows = #method_impl_prefix.delete(#index_name);
 
                                 if count_of_rows_to_delete.ne(&count_of_deleted_rows) {
@@ -1424,46 +1435,45 @@ pub(in crate::internal) fn for_method(
                             }
                         },
                         DSLMethod::DeleteOne(_) => {
-                            let get_row_to_delete =
-                                match is_multi_column_index {
-                                    true => {
-                                        let multi_column_index_check =
-                                            get_unique_multi_column_index_check(
-                                                &Action::Delete,
-                                                &singular_table_name,
-                                                &index_name,
-                                                &column_names_and_row_values,
-                                                &row_value_getters,
-                                            );
+                            let get_row_to_delete = match is_multi_column_index {
+                                true => {
+                                    let multi_column_index_check =
+                                        get_unique_multi_column_index_check(
+                                            &Action::Delete,
+                                            &singular_table_name,
+                                            &index_name,
+                                            &column_names_and_row_values,
+                                            &row_value_getters,
+                                        );
 
+                                    quote! {
+                                        let #index_name = (#(#row_value_getters),*);
+
+                                        let mut #field_name_for_found_value: Option<#struct_name> = None;
+
+                                        #multi_column_index_check
+
+                                        let row_to_delete = #field_name_for_found_value;
+                                    }
+                                }
+                                false => {
+                                    let column_name = &index_columns[0];
+                                    let column_type = &internal_columns.iter().find(|c| c.rust_field_name.eq(column_name)).expect("The index should have a column in the internal columns").rust_field_type_name_or_path;
+                                    if column_type.to_token_stream().to_string().eq(&"String") {
                                         quote! {
-                                            let #index_name = (#(#row_value_getters),*);
+                                            let #index_name = #(#row_value_getters),*;
 
-                                            let mut #field_name_for_found_value: Option<#struct_name> = None;
+                                            let row_to_delete = #method_impl_prefix.find(&#index_name);
+                                        }
+                                    } else {
+                                        quote! {
+                                            let #index_name = #(#row_value_getters),*;
 
-                                            #multi_column_index_check
-
-                                            let row_to_delete = #field_name_for_found_value;
+                                            let row_to_delete = #method_impl_prefix.find(#index_name);
                                         }
                                     }
-                                    false => {
-                                        let column_name = &index_columns[0];
-                                        let column_type = &internal_columns.iter().find(|c| c.rust_field_name.eq(column_name)).expect("The index should have a column in the internal columns").rust_field_type_name_or_path;
-                                        if column_type.to_token_stream().to_string().eq(&"String") {
-                                            quote! {
-                                                let #index_name = #(#row_value_getters),*;
-
-                                                let row_to_delete = #method_impl_prefix.find(&#index_name);
-                                            }
-                                        } else {
-                                            quote! {
-                                                let #index_name = #(#row_value_getters),*;
-
-                                                let row_to_delete = #method_impl_prefix.find(#index_name);
-                                            }
-                                        }
-                                    }
-                                };
+                                }
+                            };
 
                             let impl_until_return_err_on_is_none = quote! {
                                 use spacetimedsl::itertools::Itertools;

--- a/derive-input/src/internal/dsl/method.rs
+++ b/derive-input/src/internal/dsl/method.rs
@@ -48,6 +48,8 @@ pub(in crate::internal) enum DSLMethod<'a> {
 
 // FIXME: Ensure that struct_name is only used in doc comments, not in generated code
 
+// FIXME: Rename wrap to create_wrapper and wrapped to use_wrapper
+
 #[derive(Debug)]
 pub enum OneOrMultiple {
     One,
@@ -643,12 +645,8 @@ pub(in crate::internal) fn for_method(
             column_names_and_row_values.push_str(&format!("{singular_table_name} : "));
             column_names_and_row_values.push_str("{:?} }}");
 
-            let multi_column_index_checks = multi_column_index_checks(
-                Action::Create,
-                &singular_table_name,
-                &spacetimedb_table,
-                None,
-            );
+            let multi_column_index_checks =
+                multi_column_index_checks(Action::Create, &singular_table_name, &spacetimedb_table);
 
             let use_itertools = if multi_column_index_checks.len() > 0 {
                 quote! {
@@ -929,7 +927,6 @@ pub(in crate::internal) fn for_method(
                         Action::Update,
                         &singular_table_name,
                         &spacetimedb_table,
-                        Some(&column_names_and_row_values),
                     );
 
                     let mut row_value_getters = vec![];
@@ -978,7 +975,7 @@ pub(in crate::internal) fn for_method(
                         spacetimedb_table,
                         internal_columns,
                         paths_of_traits_to_extend,
-                        Some((&column_names_and_row_values, &row_value_getters)),
+                        Some(&column_names_and_row_values),
                     );
                     paths_of_traits_to_extend = res.0;
                     let reference_integrity_checks = res.1;
@@ -1707,7 +1704,7 @@ fn reference_integrity_checks_on_create_or_update(
     spacetimedb_table: &SpacetimeDBTable,
     columns: &Vec<InternalColumn>,
     mut paths_of_traits_to_extend: Vec<Path>,
-    column_names_and_row_value_getters: Option<(&String, &Vec<TokenStream>)>,
+    column_names_and_row_values: Option<&String>,
 ) -> (Vec<Path>, Vec<TokenStream>) {
     let mut reference_integrity_checks = vec![];
 
@@ -1783,10 +1780,6 @@ fn reference_integrity_checks_on_create_or_update(
                 }
             }
             CreateOrUpdate::Update => {
-                let column_names_and_row_value_getters = column_names_and_row_value_getters
-                    .expect("Update Method should have column_names_and_row_value_getters");
-                let column_names_and_row_values = column_names_and_row_value_getters.0;
-                let row_value_getters = column_names_and_row_value_getters.1;
                 quote! {
                     if #field_name_for_found_value.is_none() {
                         #field_name_for_found_value = match self.ctx().db().#referencing_table_name().id().find(#referencing_table_name.get_id().value()) {
@@ -1795,7 +1788,7 @@ fn reference_integrity_checks_on_create_or_update(
                                 return Err(
                                     spacetimedsl::SpacetimeDSLError::NotFoundError {
                                         table_name: #referencing_table_name_as_string.into(),
-                                        column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*).into()
+                                        column_names_and_row_values: format!(#column_names_and_row_values, #referencing_table_column_name).into()
                                     }
                                 );
                             }
@@ -1809,7 +1802,7 @@ fn reference_integrity_checks_on_create_or_update(
                                     spacetimedsl::ReferenceIntegrityViolationError::OnCreateOrUpdate {
                                         table_name: #referencing_table_name_as_string.into(),
                                         create_or_update: spacetimedsl::Action::Update,
-                                        column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*).into()
+                                        column_names_and_row_values: format!(#column_names_and_row_values, #referencing_table_column_name).into()
                                     }
                                 )
                             )
@@ -1843,7 +1836,6 @@ fn multi_column_index_checks(
     action: Action,
     singular_table_name: &Ident,
     spacetimedb_table: &SpacetimeDBTable,
-    column_names_and_row_values: Option<&String>,
 ) -> Vec<TokenStream> {
     let mut multi_column_index_checks = vec![];
     let singular_table_name_as_string = singular_table_name.to_string();
@@ -1863,44 +1855,31 @@ fn multi_column_index_checks(
         let index_name = &multi_column_index.name;
 
         let mut row_value_getters = vec![];
+        let mut column_names_and_row_values = String::new();
 
-        let column_names_and_row_values = match column_names_and_row_values {
-            Some(column_names_and_row_values) => {
-                for column_name in &index_column_names {
-                    row_value_getters.push(quote! {#singular_table_name.#column_name});
-                }
-                column_names_and_row_values.clone()
-            }
-            None => {
-                let mut column_names_and_row_values = String::new();
+        let first_column_name = index_column_names
+            .pop_front()
+            .expect("There should be a first column in Vec<Ident> of BTreeMultiColumn.");
 
-                let first_column_name = index_column_names
-                    .pop_front()
-                    .expect("There should be a first column in Vec<Ident> of BTreeMultiColumn.");
+        let last_column_name = index_column_names
+            .pop_back()
+            .expect("There should be a last column in Vec<Ident> of BTreeMultiColumn.");
 
-                let last_column_name = index_column_names
-                    .pop_back()
-                    .expect("There should be a last column in Vec<Ident> of BTreeMultiColumn.");
+        let any_other_column_name = index_column_names;
 
-                let any_other_column_name = index_column_names;
+        column_names_and_row_values.push_str(&format!("{first_column_name} : "));
+        column_names_and_row_values.push_str("{} ");
+        row_value_getters.push(quote! {#singular_table_name.#first_column_name});
 
-                column_names_and_row_values.push_str(&format!("{first_column_name} : "));
-                column_names_and_row_values.push_str("{} ");
-                row_value_getters.push(quote! {#singular_table_name.#first_column_name});
+        for any_other_column_name in any_other_column_name {
+            column_names_and_row_values.push_str(&format!(", {any_other_column_name} : "));
+            column_names_and_row_values.push_str("{} ");
+            row_value_getters.push(quote! {#singular_table_name.#any_other_column_name});
+        }
 
-                for any_other_column_name in any_other_column_name {
-                    column_names_and_row_values.push_str(&format!(", {any_other_column_name} : "));
-                    column_names_and_row_values.push_str("{} ");
-                    row_value_getters.push(quote! {#singular_table_name.#any_other_column_name});
-                }
-
-                column_names_and_row_values.push_str(&format!(", {last_column_name} : "));
-                column_names_and_row_values.push_str("{}");
-                row_value_getters.push(quote! {#singular_table_name.#last_column_name});
-
-                column_names_and_row_values
-            }
-        };
+        column_names_and_row_values.push_str(&format!(", {last_column_name} : "));
+        column_names_and_row_values.push_str("{}");
+        row_value_getters.push(quote! {#singular_table_name.#last_column_name});
 
         let mut multi_column_index_check = get_unique_multi_column_index_check(
             &action,

--- a/derive-input/src/internal/dsl/method.rs
+++ b/derive-input/src/internal/dsl/method.rs
@@ -1446,11 +1446,23 @@ pub(in crate::internal) fn for_method(
                                             let primary_key_value_of_a_row_to_delete = #field_name_for_found_value;
                                         }
                                     }
-                                    false => quote! {
-                                        let #index_name = #(#row_value_getters),*;
+                                    false => {
+                                        let column_name = &index_columns[0];
+                                        let column_type = &internal_columns.iter().find(|c| c.rust_field_name.eq(column_name)).expect("The index should have a column in the internal columns").rust_field_type_name_or_path;
+                                        if column_type.to_token_stream().to_string().eq(&"String") {
+                                            quote! {
+                                                let #index_name = #(#row_value_getters),*;
 
-                                        let primary_key_value_of_a_row_to_delete = #method_impl_prefix.find(#index_name);
-                                    },
+                                                let primary_key_value_of_a_row_to_delete = #method_impl_prefix.find(&#index_name);
+                                            }
+                                        } else {
+                                            quote! {
+                                                let #index_name = #(#row_value_getters),*;
+
+                                                let primary_key_value_of_a_row_to_delete = #method_impl_prefix.find(#index_name);
+                                            }
+                                        }
+                                    }
                                 };
 
                             let impl_until_return_err_on_is_none = quote! {

--- a/derive-input/src/internal/dsl/method.rs
+++ b/derive-input/src/internal/dsl/method.rs
@@ -1424,7 +1424,7 @@ pub(in crate::internal) fn for_method(
                             }
                         },
                         DSLMethod::DeleteOne(_) => {
-                            let get_primary_key_value_of_a_row_to_delete =
+                            let get_row_to_delete =
                                 match is_multi_column_index {
                                     true => {
                                         let multi_column_index_check =
@@ -1443,7 +1443,7 @@ pub(in crate::internal) fn for_method(
 
                                             #multi_column_index_check
 
-                                            let primary_key_value_of_a_row_to_delete = #field_name_for_found_value;
+                                            let row_to_delete = #field_name_for_found_value;
                                         }
                                     }
                                     false => {
@@ -1453,13 +1453,13 @@ pub(in crate::internal) fn for_method(
                                             quote! {
                                                 let #index_name = #(#row_value_getters),*;
 
-                                                let primary_key_value_of_a_row_to_delete = #method_impl_prefix.find(&#index_name);
+                                                let row_to_delete = #method_impl_prefix.find(&#index_name);
                                             }
                                         } else {
                                             quote! {
                                                 let #index_name = #(#row_value_getters),*;
 
-                                                let primary_key_value_of_a_row_to_delete = #method_impl_prefix.find(#index_name);
+                                                let row_to_delete = #method_impl_prefix.find(#index_name);
                                             }
                                         }
                                     }
@@ -1470,16 +1470,16 @@ pub(in crate::internal) fn for_method(
 
                                 #(#wrapper_type_option_to_wrapped_type_option_mappers)*
 
-                                #get_primary_key_value_of_a_row_to_delete
+                                #get_row_to_delete
 
-                                let primary_key_value_of_a_row_to_delete = match primary_key_value_of_a_row_to_delete {
+                                let primary_key_value_of_a_row_to_delete = match row_to_delete {
                                     None => return Err(
                                         spacetimedsl::SpacetimeDSLError::NotFoundError {
                                             table_name: #singular_table_name_as_string.into(),
                                             column_names_and_row_values: format!(#column_names_and_row_values, &#index_name).into()
                                         }
                                     ),
-                                    Some(primary_key_value_of_a_row_to_delete) => primary_key_value_of_a_row_to_delete.id,
+                                    Some(row_to_delete) => row_to_delete.id,
                                 };
                             };
 

--- a/derive-input/src/internal/dsl/method.rs
+++ b/derive-input/src/internal/dsl/method.rs
@@ -1756,10 +1756,8 @@ fn reference_integrity_checks_on_create_or_update(
             "{}",
             RenameRule::PascalCase.apply_to_field(referenced_table_name.to_string())
         );
-        let referenced_table_primary_key_column_name_pascal_case = format_ident!("Id");
-        let get_row_of_referenced_table_by_primary_key_trait_name = format_ident!(
-            "Get{referenced_table_name_pascal_case}RowOptionBy{referenced_table_primary_key_column_name_pascal_case}"
-        );
+        let get_row_of_referenced_table_by_primary_key_trait_name =
+            format_ident!("Get{referenced_table_name_pascal_case}RowOptionById");
         let get_row_of_referenced_table_by_primary_key_method_name =
             format_ident!("get_{referenced_table_name}_by_id");
 

--- a/derive-input/src/internal/dsl/method.rs
+++ b/derive-input/src/internal/dsl/method.rs
@@ -281,9 +281,8 @@ impl SpacetimeDSLTableMethods {
                     execute_on_delete_strategies_of_this_table_after_one_row_of_the_referenced_table_was_deleted.push(
                         for_foreign_key(
                             &OneOrMultiple::One,
-                            spacetimedsl_table.referencing_tables.is_empty(),
+                            !spacetimedsl_table.referencing_tables.is_empty(),
                             spacetimedb_table,
-                            columns,
                             referenced_table_name,
                             &columns_with_foreign_key,
                         )
@@ -291,9 +290,8 @@ impl SpacetimeDSLTableMethods {
                     execute_on_delete_strategies_of_this_table_after_multiple_rows_of_the_referenced_table_were_deleted.push(
                         for_foreign_key(
                             &OneOrMultiple::Multiple,
-                            spacetimedsl_table.referencing_tables.is_empty(),
+                            !spacetimedsl_table.referencing_tables.is_empty(),
                             spacetimedb_table,
-                            columns,
                             referenced_table_name,
                             &columns_with_foreign_key,
                         )
@@ -1410,7 +1408,7 @@ pub(in crate::internal) fn for_method(
                                             return Err(
                                                 spacetimedsl::SpacetimeDSLError::NotFoundError {
                                                     table_name: #singular_table_name_as_string.into(),
-                                                    column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*)
+                                                    column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*).into()
                                                 }
                                             );
                                         }
@@ -1426,7 +1424,7 @@ pub(in crate::internal) fn for_method(
                                         None => return Err(
                                             spacetimedsl::SpacetimeDSLError::NotFoundError {
                                                 table_name: #singular_table_name_as_string.into(),
-                                                column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*)
+                                                column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*).into()
                                             }
                                         )
                                     }
@@ -1476,7 +1474,7 @@ pub(in crate::internal) fn for_method(
                                     None => return Err(
                                         spacetimedsl::SpacetimeDSLError::NotFoundError {
                                             table_name: #singular_table_name_as_string.into(),
-                                            column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*)
+                                            column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*).into()
                                         }
                                     );,
                                     Some(primary_key_value_of_a_row_to_delete) => primary_key_value_of_a_row_to_delete,
@@ -1660,8 +1658,8 @@ fn get_referenced_table_function_call_for_dsl_method(
 
             quote! {
                 match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), #on_delete_strategy, primary_key_value_of_a_row_to_delete) {
-                    Err(child_entries) => {
-                        deletion_result_entry.child_entries.append(child_entries);
+                    Err(mut child_entries) => {
+                        deletion_result_entry.child_entries.append(&mut child_entries);
 
                         error = Some(spacetimedsl::DeletionResult {
                             table_name: #singular_table_name_as_string.into(),
@@ -1669,8 +1667,8 @@ fn get_referenced_table_function_call_for_dsl_method(
                             entries: vec![deletion_result_entry],
                         });
                     },
-                    Ok(child_entries) => {
-                        deletion_result_entry.child_entries.append(child_entries);
+                    Ok(mut child_entries) => {
+                        deletion_result_entry.child_entries.append(&mut child_entries);
                     }
                 };
             }
@@ -1680,10 +1678,10 @@ fn get_referenced_table_function_call_for_dsl_method(
                 get_referenced_table_function_name(&OneOrMultiple::Multiple, &singular_table_name);
 
             quote! {
-                match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), #on_delete_strategy, primary_key_values_of_rows_to_delete) {
+                match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), #on_delete_strategy, &primary_key_values_of_rows_to_delete[..]) {
                     Err(child_entries_by_primary_key_value_of_a_row_to_delete) => {
-                        for (primary_key_value_of_a_row_to_delete, child_entries) in child_entries_by_primary_key_value_of_a_row_to_delete {
-                            deletion_result_entries.get_mut(primary_key_value_of_a_row_to_delete).unwrap().child_entries.append(child_entries);
+                        for (primary_key_value_of_a_row_to_delete, mut child_entries) in child_entries_by_primary_key_value_of_a_row_to_delete {
+                            deletion_result_entries.get_mut(primary_key_value_of_a_row_to_delete).unwrap().child_entries.append(&mut child_entries);
                         }
 
                         error = Some(spacetimedsl::DeletionResult {
@@ -1693,8 +1691,8 @@ fn get_referenced_table_function_call_for_dsl_method(
                         });
                     },
                     Ok(child_entries_by_primary_key_value_of_a_row_to_delete) => {
-                        for (primary_key_value_of_a_row_to_delete, child_entries) in child_entries_by_primary_key_value_of_a_row_to_delete {
-                            deletion_result_entries.get_mut(primary_key_value_of_a_row_to_delete).unwrap().child_entries.append(child_entries);
+                        for (primary_key_value_of_a_row_to_delete, mut child_entries) in child_entries_by_primary_key_value_of_a_row_to_delete {
+                            deletion_result_entries.get_mut(primary_key_value_of_a_row_to_delete).unwrap().child_entries.append(&mut child_entries);
                         }
                     }
                 };
@@ -1778,7 +1776,7 @@ fn reference_integrity_checks_on_create_or_update(
                                     spacetimedsl::ReferenceIntegrityViolationError::OnCreateOrUpdate {
                                         table_name: #referencing_table_name_as_string.into(),
                                         create_or_update: spacetimedsl::Action::Create,
-                                        column_names_and_row_values: format!(#column_names_and_row_values, #referencing_table_name.#referencing_table_column_getter_name())
+                                        column_names_and_row_values: format!(#column_names_and_row_values, #referencing_table_name.#referencing_table_column_getter_name()).into()
                                     }
                                 )
                             );
@@ -1797,7 +1795,7 @@ fn reference_integrity_checks_on_create_or_update(
                                 return Err(
                                     spacetimedsl::SpacetimeDSLError::NotFoundError {
                                         table_name: #referencing_table_name_as_string.into(),
-                                        column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*)
+                                        column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*).into()
                                     }
                                 );
                             }
@@ -1811,7 +1809,7 @@ fn reference_integrity_checks_on_create_or_update(
                                     spacetimedsl::ReferenceIntegrityViolationError::OnCreateOrUpdate {
                                         table_name: #referencing_table_name_as_string.into(),
                                         create_or_update: spacetimedsl::Action::Update,
-                                        column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*)
+                                        column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*).into()
                                     }
                                 )
                             )
@@ -1893,7 +1891,7 @@ fn multi_column_index_checks(
                     action: spacetimedsl::Action::#action_as_ident,
                     error_from: spacetimedsl::ErrorFrom::SpacetimeDSL,
                     one_or_multiple: #multiple,
-                    column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*)
+                    column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*).into()
                 }
             );
         };
@@ -1950,7 +1948,7 @@ pub(in crate::internal::dsl::method) fn get_unique_multi_column_index_check(
                     action: spacetimedsl::Action::#action,
                     error_from: spacetimedsl::ErrorFrom::SpacetimeDSL,
                     one_or_multiple: #multiple,
-                    column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*)
+                    column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*).into()
                 }
             ),
         };
@@ -2023,7 +2021,7 @@ fn for_referenced_by(
                 is_mut: false,
                 arg_name: arg_name.clone(),
                 arg_type: quote! {
-                    &'a Vec<#primary_key_column_type>
+                    &'a [#primary_key_column_type]
                 },
             });
             return_type = quote! {
@@ -2108,7 +2106,7 @@ fn for_referenced_by(
                                 error = true;
                             },
                             Ok(child_entries_by_primary_key_value_of_a_row_to_delete) => {
-                                for (primary_key_value_of_a_row_to_delete, child_entries) in child_entries_by_primary_key_value_of_a_row_to_delete {
+                                for (primary_key_value_of_a_row_to_delete, mut child_entries) in child_entries_by_primary_key_value_of_a_row_to_delete {
                                     entries.get_mut(&primary_key_value_of_a_row_to_delete).unwrap().append(&mut child_entries);
                                 }
                             },
@@ -2148,7 +2146,6 @@ fn for_foreign_key(
     one_or_multiple: &OneOrMultiple,
     has_referenced_bys: bool,
     spacetimedb_table: &SpacetimeDBTable,
-    columns: &Vec<Column>,
     referenced_table_name: &syn::Ident,
     columns_with_foreign_key: &Vec<&&Column>,
 ) -> SpacetimeDSLMethod {
@@ -2264,13 +2261,13 @@ fn for_foreign_key(
                 is_mut: false,
                 arg_name: arg_name.clone(),
                 arg_type: quote! {
-                    &Vec<#referenced_table_primary_key_column_type>
+                    &'a [#referenced_table_primary_key_column_type]
                 },
             });
             return_type = quote! {
                 Result<
-                    std::collections::HashMap<&#referenced_table_primary_key_column_type, Vec<spacetimedsl::DeletionResultEntry>>,
-                    std::collections::HashMap<&#referenced_table_primary_key_column_type, Vec<spacetimedsl::DeletionResultEntry>>
+                    std::collections::HashMap<&'a #referenced_table_primary_key_column_type, Vec<spacetimedsl::DeletionResultEntry>>,
+                    std::collections::HashMap<&'a #referenced_table_primary_key_column_type, Vec<spacetimedsl::DeletionResultEntry>>
                 >
             };
         }
@@ -2505,15 +2502,15 @@ fn get_on_delete_strategy_implementation(
 
                         strategy_for_each_row = quote! {
                             if !child_entries_by_primary_key_value_of_row_to_delete.contains_key(&row.id) {
-                                primary_key_values_of_rows_to_delete_by_primary_key_value_of_a_row_of_another_table_to_delete.get_mut(primary_key_value_of_a_row_of_another_table_to_delete).unwrap().push(&row.id);
-                                child_entries_by_primary_key_value_of_row_to_delete.insert(&row.id, vec![]);
+                                primary_key_values_of_rows_to_delete_by_primary_key_value_of_a_row_of_another_table_to_delete.get_mut(primary_key_value_of_a_row_of_another_table_to_delete).unwrap().push(row.id);
+                                child_entries_by_primary_key_value_of_row_to_delete.insert(row.id, vec![]);
                             }
                         };
 
                         let create_entries_and_add_them_to_entries = quote! {
                             for (primary_key_value_of_a_row_of_another_table_to_delete, primary_key_values_of_rows_to_delete) in primary_key_values_of_rows_to_delete_by_primary_key_value_of_a_row_of_another_table_to_delete {
-                                for id in primary_key_values_of_rows_to_delete {
-                                    let child_entries = child_entries_by_primary_key_value_of_row_to_delete.remove(id).unwrap();
+                                for id in &primary_key_values_of_rows_to_delete {
+                                    let child_entries = child_entries_by_primary_key_value_of_row_to_delete.remove(&id).unwrap();
                                     #create_entry_and_add_it_to_entries
                                 }
                             }
@@ -2530,7 +2527,7 @@ fn get_on_delete_strategy_implementation(
                         };
 
                         strategy_after_all = quote! {
-                            let primary_key_values_of_rows_to_delete = child_entries_by_primary_key_value_of_row_to_delete.keys().collect_vec();
+                            let primary_key_values_of_rows_to_delete = child_entries_by_primary_key_value_of_row_to_delete.keys().cloned().collect_vec();
 
                             #error_strategy
 
@@ -2542,7 +2539,7 @@ fn get_on_delete_strategy_implementation(
                                 }
                             };
 
-                            for id in primary_key_values_of_rows_to_delete {
+                            for id in &primary_key_values_of_rows_to_delete {
                                 #spacetimedb_call_prefix
                                     .id()
                                     .delete(id);
@@ -2584,13 +2581,13 @@ fn get_on_delete_strategy_implementation(
                     quote! {
                         row.#column_name = 0;
 
-                        // FIXME: try_update instead of update
-                        // FIXME: on error return Err(spacetimedsl::SpacetimeDSLError);
-                        #spacetimedb_call_prefix.id().update(row);
-
                         let child_entries = vec![];
                         let id = &row.id;
                         #create_entry_and_add_it_to_entries
+
+                        // FIXME: try_update instead of update
+                        // FIXME: on error return Err(spacetimedsl::SpacetimeDSLError);
+                        #spacetimedb_call_prefix.id().update(row);
                     },
                 ));
             }
@@ -2669,17 +2666,17 @@ fn get_referenced_table_function_call_for_strategy_implementation(
         get_referenced_table_function_name(&OneOrMultiple::Multiple, &singular_table_name);
 
     quote! {
-        match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(ctx, #on_delete_strategy, primary_key_values_of_rows_to_delete) {
+        match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(ctx, #on_delete_strategy, &primary_key_values_of_rows_to_delete[..]) {
             Err(child_entries_by_primary_key_value_of_a_row_to_delete) => {
                 error = true;
 
-                for (primary_key_value_of_a_row_to_delete, child_entries) in child_entries_by_primary_key_value_of_a_row_to_delete {
-                    child_entries_by_primary_key_value_of_row_to_delete.get_mut(primary_key_value_of_a_row_to_delete).unwrap().append(child_entries);
+                for (primary_key_value_of_a_row_to_delete, mut child_entries) in child_entries_by_primary_key_value_of_a_row_to_delete {
+                    child_entries_by_primary_key_value_of_row_to_delete.get_mut(primary_key_value_of_a_row_to_delete).unwrap().append(&mut child_entries);
                 }
             },
             Ok(child_entries_by_primary_key_value_of_a_row_to_delete) => {
-                for (primary_key_value_of_a_row_to_delete, child_entries) in child_entries_by_primary_key_value_of_a_row_to_delete {
-                    child_entries_by_primary_key_value_of_row_to_delete.get_mut(primary_key_value_of_a_row_to_delete).unwrap().append(child_entries);
+                for (primary_key_value_of_a_row_to_delete, mut child_entries) in child_entries_by_primary_key_value_of_a_row_to_delete {
+                    child_entries_by_primary_key_value_of_row_to_delete.get_mut(primary_key_value_of_a_row_to_delete).unwrap().append(&mut child_entries);
                 }
             }
         };

--- a/derive-input/src/internal/dsl/method.rs
+++ b/derive-input/src/internal/dsl/method.rs
@@ -1,10 +1,12 @@
 use crate::{
     api::{
+        Column,
         db::{
             column::SpacetimeDBColumn,
             index::{Index, IndexType},
             table::SpacetimeDBTable,
-        }, dsl::{
+        },
+        dsl::{
             column::{
                 SpacetimeDSLColumnMethods, SpacetimeDSLColumnMethodsForIndex,
                 SpacetimeDSLColumnMethodsForUniqueIndex,
@@ -13,15 +15,23 @@ use crate::{
             method::{SpacetimeDSLMethod, SpacetimeDSLMethodArg},
             table::{SpacetimeDSLTable, SpacetimeDSLTableMethods},
             wrapper::WrapperType,
-        }, rust::{table::RustStruct, visibility::RustVisibility}, Column
+        },
+        rust::{table::RustStruct, visibility::RustVisibility},
     },
-    internal::{column::InternalColumn, dsl::wrapper::map_wrapper_type_option_to_wrapped_type_option},
+    internal::{
+        column::InternalColumn, dsl::wrapper::map_wrapper_type_option_to_wrapped_type_option,
+    },
 };
 use ident_case::RenameRule;
+use itertools::Itertools;
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote, ToTokens, TokenStreamExt};
-use std::collections::{HashMap, VecDeque};
-use syn::{parse_str, Ident, Path};
+use quote::{ToTokens, TokenStreamExt, format_ident, quote};
+use std::{
+    collections::{HashMap, VecDeque},
+    fmt::{self, Display},
+};
+use strum::IntoEnumIterator;
+use syn::{Ident, Path, parse_str};
 
 pub(in crate::internal) enum DSLMethod<'a> {
     Create,
@@ -34,17 +44,46 @@ pub(in crate::internal) enum DSLMethod<'a> {
     DeleteOne(&'a Index),
 }
 
+// FIXME: Ensure that any panic! / expect() / unwrap() is replaced by proper error handling, either returning spacetimedsl::SpacetimeDSLError during runtime or syn::Error during compilation time
+
 #[derive(PartialEq)]
-enum CreateOrUpdateDSLMethod {
+enum CreateOrUpdate {
     Create,
-    Update
+    Update,
+}
+
+impl Display for CreateOrUpdate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CreateOrUpdate::Create => write!(f, "Create"),
+            CreateOrUpdate::Update => write!(f, "Update"),
+        }
+    }
+}
+
+#[derive(PartialEq)]
+enum Action {
+    Create,
+    Get,
+    Update,
+    Delete,
+}
+
+impl Display for Action {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Action::Create => write!(f, "Create"),
+            Action::Get => write!(f, "Get"),
+            Action::Update => write!(f, "Update"),
+            Action::Delete => write!(f, "Delete"),
+        }
+    }
 }
 
 pub(in crate::internal) enum DSLInternalReferencedByFunction {
     ExecuteOnDeleteStrategiesOfReferencingTablesAfterOneRowOfThisTableWasDeleted,
     ExecuteOnDeleteStrategiesOfReferencingTablesAfterMultipleRowsOfThisTableWereDeleted,
 }
-
 
 pub(in crate::internal) enum DSLInternalForeignKeyFunction {
     ExecuteOnDeleteStrategiesOfThisTableAfterOneRowOfTheReferencedTableWasDeleted,
@@ -106,11 +145,11 @@ impl SpacetimeDSLColumnMethods {
                     false => None,
                     true => Some(for_method(
                         DSLMethod::Update(index),
-                    rust_struct,
-                    spacetimedb_table,
-                    spacetimedsl_table,
-                    primary_key_column_name,
-                    internal_columns,
+                        rust_struct,
+                        spacetimedb_table,
+                        spacetimedsl_table,
+                        primary_key_column_name,
+                        internal_columns,
                     )),
                 };
 
@@ -345,7 +384,15 @@ impl SpacetimeDSLTableMethods {
     }
 }
 
-fn process_columns_for_create_and_update_method(create_or_update: CreateOrUpdateDSLMethod, internal_column: &InternalColumn) -> (Option<SpacetimeDSLMethodArg>, Option<TokenStream>, Option<TokenStream>, TokenStream) {
+fn process_columns_for_create_and_update_method(
+    create_or_update: CreateOrUpdate,
+    internal_column: &InternalColumn,
+) -> (
+    Option<SpacetimeDSLMethodArg>,
+    Option<TokenStream>,
+    Option<TokenStream>,
+    TokenStream,
+) {
     let mut method_arg = None;
     let mut wrapper_type_option_to_wrapped_type_option_mapper = None;
     let mut constructor_arg = None;
@@ -359,62 +406,83 @@ fn process_columns_for_create_and_update_method(create_or_update: CreateOrUpdate
     let column_type = &internal_column.rust_field_type_name_or_path;
 
     match create_or_update {
-        CreateOrUpdateDSLMethod::Create => {
-            // TODO: https://github.com/tamaro-skaljic/SpacetimeDSL/issues/37
+        CreateOrUpdate::Create => {
             if internal_column.spacetimedb_column_is_auto_inc
-                || internal_column.rust_field_name.to_string().eq(&"created_at")
-                || internal_column.rust_field_name.to_string().eq(&"modified_at")
+                || internal_column
+                    .rust_field_name
+                    .to_string()
+                    .eq(&"created_at")
+                || internal_column
+                    .rust_field_name
+                    .to_string()
+                    .eq(&"modified_at")
             {
                 if internal_column.spacetimedb_column_is_auto_inc {
                     constructor_arg = Some(quote! {
                         let #column_name = #column_type::default();
                     });
-                } else if internal_column.rust_field_name.to_string().eq(&"created_at") {
+                } else if internal_column
+                    .rust_field_name
+                    .to_string()
+                    .eq(&"created_at")
+                {
                     constructor_arg = Some(quote! {
                         let created_at = self.ctx().timestamp;
                     });
-                } else if internal_column.rust_field_name.to_string().eq(&"modified_at") {
+                } else if internal_column
+                    .rust_field_name
+                    .to_string()
+                    .eq(&"modified_at")
+                {
+                    // TODO: https://github.com/tamaro-skaljic/SpacetimeDSL/issues/37
                     constructor_arg = Some(quote! {
                         let modified_at = self.ctx().timestamp;
                     });
                 }
-                return (method_arg, wrapper_type_option_to_wrapped_type_option_mapper, constructor_arg, constructor_arg_name);
+                return (
+                    method_arg,
+                    wrapper_type_option_to_wrapped_type_option_mapper,
+                    constructor_arg,
+                    constructor_arg_name,
+                );
             }
-        },
-        CreateOrUpdateDSLMethod::Update => {
-
-        },
+        }
+        CreateOrUpdate::Update => {}
     };
 
     match &internal_column.spacetimedsl_column_wrapper_type {
         Some(wrapper_type) => match wrapper_type {
             WrapperType::Wrap(wrapper_type) => {
-                if internal_column.rust_field_type_name_or_path.to_token_stream().to_string().eq(&"String") {
+                if internal_column
+                    .rust_field_type_name_or_path
+                    .to_token_stream()
+                    .to_string()
+                    .eq(&"String")
+                {
                     method_arg = Some(SpacetimeDSLMethodArg {
                         is_mut: false,
                         arg_name: column_name.clone(),
-                        arg_type: quote! { &str }
+                        arg_type: quote! { &str },
                     });
                     match create_or_update {
-                        CreateOrUpdateDSLMethod::Create => {
+                        CreateOrUpdate::Create => {
                             constructor_arg = Some(quote! {
                                 let #column_name = #column_name.to_string();
                             });
-                        },
-                        CreateOrUpdateDSLMethod::Update => {
+                        }
+                        CreateOrUpdate::Update => {
                             constructor_arg = Some(quote! {
                                 let #column_name = #singular_table_name.#getter_name();
                             });
-                        },
+                        }
                     };
                 } else {
-                    let wrapped_type_name_or_path =
-                        WrapperType::map_to_wrapped_type(wrapper_type);
-                        
+                    let wrapped_type_name_or_path = WrapperType::map_to_wrapped_type(wrapper_type);
+
                     method_arg = Some(SpacetimeDSLMethodArg {
                         is_mut: false,
                         arg_name: column_name.clone(),
-                        arg_type: quote! { #wrapped_type_name_or_path }
+                        arg_type: quote! { #wrapped_type_name_or_path },
                     });
                 }
             }
@@ -425,64 +493,75 @@ fn process_columns_for_create_and_update_method(create_or_update: CreateOrUpdate
                     method_arg = Some(SpacetimeDSLMethodArg {
                         is_mut: false,
                         arg_name: column_name.clone(),
-                        arg_type: quote! { impl Into<Option<#wrapper_type_name_or_path>> }
+                        arg_type: quote! { impl Into<Option<#wrapper_type_name_or_path>> },
                     });
-                    wrapper_type_option_to_wrapped_type_option_mapper = Some(map_wrapper_type_option_to_wrapped_type_option(
-                        &column_name,
-                        wrapper_type_name_or_path,
-                    ));
+                    wrapper_type_option_to_wrapped_type_option_mapper =
+                        Some(map_wrapper_type_option_to_wrapped_type_option(
+                            &column_name,
+                            wrapper_type_name_or_path,
+                        ));
                 } else {
                     method_arg = Some(SpacetimeDSLMethodArg {
                         is_mut: false,
                         arg_name: column_name.clone(),
-                        arg_type: quote! { impl Into<#wrapper_type_name_or_path> }
+                        arg_type: quote! { impl Into<#wrapper_type_name_or_path> },
                     });
                     match create_or_update {
-                        CreateOrUpdateDSLMethod::Create => {
+                        CreateOrUpdate::Create => {
                             constructor_arg = Some(quote! {
                                 let #column_name = #column_name.into().value();
                             });
-                        },
-                        CreateOrUpdateDSLMethod::Update => {
+                        }
+                        CreateOrUpdate::Update => {
                             constructor_arg = Some(quote! {
                                 let #column_name = #singular_table_name.#getter_name().value();
                             });
-                        },
+                        }
                     };
                 }
             }
         },
         None => {
-            if internal_column.rust_field_type_name_or_path.to_token_stream().to_string().eq(&"String") {
+            if internal_column
+                .rust_field_type_name_or_path
+                .to_token_stream()
+                .to_string()
+                .eq(&"String")
+            {
                 method_arg = Some(SpacetimeDSLMethodArg {
                     is_mut: false,
                     arg_name: column_name.clone(),
-                    arg_type: quote! { &str }
+                    arg_type: quote! { &str },
                 });
 
                 match create_or_update {
-                    CreateOrUpdateDSLMethod::Create => {
+                    CreateOrUpdate::Create => {
                         constructor_arg = Some(quote! {
                             let #column_name = #column_name.to_string();
                         });
-                    },
-                    CreateOrUpdateDSLMethod::Update => {
+                    }
+                    CreateOrUpdate::Update => {
                         constructor_arg = Some(quote! {
                             let #column_name = #singular_table_name.#getter_name();
                         });
-                    },
+                    }
                 };
             } else {
                 method_arg = Some(SpacetimeDSLMethodArg {
                     is_mut: false,
                     arg_name: column_name.clone(),
-                    arg_type: quote! { #column_type }
+                    arg_type: quote! { #column_type },
                 });
             }
         }
     };
 
-    (method_arg, wrapper_type_option_to_wrapped_type_option_mapper, constructor_arg, constructor_arg_name)
+    (
+        method_arg,
+        wrapper_type_option_to_wrapped_type_option_mapper,
+        constructor_arg,
+        constructor_arg_name,
+    )
 }
 
 pub(in crate::internal) fn for_method(
@@ -491,14 +570,14 @@ pub(in crate::internal) fn for_method(
     spacetimedb_table: &SpacetimeDBTable,
     spacetimedsl_table: &SpacetimeDSLTable,
     primary_key_column_name: &Ident,
-    internal_columns: &Vec<InternalColumn>
+    internal_columns: &Vec<InternalColumn>,
 ) -> SpacetimeDSLMethod {
     let struct_name = &rust_struct.name;
     let singular_table_name = &spacetimedb_table.singular_name;
-    let singular_table_name_pascal_case = RenameRule::PascalCase.apply_to_field(singular_table_name.to_string());
+    let singular_table_name_as_string = singular_table_name.to_string();
+    let singular_table_name_pascal_case =
+        RenameRule::PascalCase.apply_to_field(singular_table_name.to_string());
     let plural_table_name = &spacetimedsl_table.plural_name;
-    
-    let try_insert_error_generic_type = format_ident!("{singular_table_name}__TableHandle");
 
     // TODO https://github.com/tamaro-skaljic/SpacetimeDSL/issues/35
     let doc_comment;
@@ -509,7 +588,8 @@ pub(in crate::internal) fn for_method(
 
     let field_name_for_found_value = format_ident!("the_same_or_another_{singular_table_name}");
 
-    let mut paths_of_traits_to_extend = vec![ parse_str("spacetimedsl::DSLContext").expect("parsing should have worked") ];
+    let mut paths_of_traits_to_extend =
+        vec![parse_str("spacetimedsl::DSLContext").expect("parsing should have worked")];
     let mut method_args = vec![];
     let method_impl;
 
@@ -522,7 +602,7 @@ pub(in crate::internal) fn for_method(
             method_name = format_ident!("create_{}", singular_table_name);
 
             return_type = quote! {
-                Result<#struct_name, spacetimedb::TryInsertError<#try_insert_error_generic_type>>
+                Result<#struct_name, spacetimedsl::SpacetimeDSLError>
             };
 
             let mut wrapper_type_option_to_wrapped_type_option_mappers = vec![];
@@ -530,59 +610,49 @@ pub(in crate::internal) fn for_method(
             let mut constructor_arg_names = vec![];
 
             for internal_column in internal_columns {
-                let (method_arg, wrapper_type_option_to_wrapped_type_option_mapper, constructor_arg, constructor_arg_name) = process_columns_for_create_and_update_method(CreateOrUpdateDSLMethod::Create, &internal_column);
+                let (
+                    method_arg,
+                    wrapper_type_option_to_wrapped_type_option_mapper,
+                    constructor_arg,
+                    constructor_arg_name,
+                ) = process_columns_for_create_and_update_method(
+                    CreateOrUpdate::Create,
+                    &internal_column,
+                );
                 match method_arg {
                     Some(method_arg) => method_args.push(method_arg),
-                    None => {},
+                    None => {}
                 }
-                
+
                 match wrapper_type_option_to_wrapped_type_option_mapper {
-                    Some(wrapper_type_option_to_wrapped_type_option_mapper) => wrapper_type_option_to_wrapped_type_option_mappers.push(wrapper_type_option_to_wrapped_type_option_mapper),
-                    None => {},
+                    Some(wrapper_type_option_to_wrapped_type_option_mapper) => {
+                        wrapper_type_option_to_wrapped_type_option_mappers
+                            .push(wrapper_type_option_to_wrapped_type_option_mapper)
+                    }
+                    None => {}
                 }
 
                 match constructor_arg {
                     Some(constructor_arg) => constructor_args.push(constructor_arg),
-                    None => {},
+                    None => {}
                 }
-                
+
                 constructor_arg_names.push(constructor_arg_name)
             }
 
-            let mut multi_column_index_checks = get_unique_multi_column_index_checks(
+            let mut column_names_and_row_values = String::new();
+            column_names_and_row_values.push_str("{{ ");
+            column_names_and_row_values.push_str(&format!("{singular_table_name} : "));
+            column_names_and_row_values.push_str("{} }}");
+
+            let multi_column_index_checks = multi_column_index_checks(
+                Action::Create,
                 &struct_name,
                 &singular_table_name,
                 &spacetimedb_table,
+                primary_key_column_name,
+                &column_names_and_row_values,
             );
-            
-            for multi_column_index_check in &mut multi_column_index_checks {
-                let field_name_for_found_value =
-                    format_ident!("the_same_or_another_{singular_table_name}");
-                let index_name = &multi_column_index_check.index_name;
-                let mut another_one_panic_msg = format!(
-                    "There must be no {struct_name} row inside the {singular_table_name} table when filtering on the unique multi-column index {index_name} with value "
-                );
-                another_one_panic_msg.push_str(
-                "{:?}. Found another one with a different value in the primary key column: {:?}. There can be two reasons for this: You are inserting or updating somewhere using spacetimedb::ReducerContext instead of spacetimedsl::DSL or the unique multi-column index SpacetimeDSL feature is broken.",
-            );
-
-                multi_column_index_check.check.append_all(quote! {
-                    match &#field_name_for_found_value {
-                        Some(#field_name_for_found_value) => {
-                            use spacetimedb::table::MaybeError;
-                            return Err(spacetimedb::UniqueConstraintViolation::get()
-                                .map(spacetimedb::TryInsertError::UniqueConstraintViolation)
-                                .expect("Mapping should have worked"));
-                        },
-                        _ => {},
-                    };
-                });
-            }
-
-            let multi_column_index_checks: Vec<TokenStream> = multi_column_index_checks
-                .into_iter()
-                .map(|mcic| mcic.check)
-                .collect();
 
             let use_itertools = if multi_column_index_checks.len() > 0 {
                 quote! {
@@ -592,11 +662,12 @@ pub(in crate::internal) fn for_method(
                 TokenStream::default()
             };
 
-            let res = reference_integrity_checks(
-                CreateOrUpdateDSLMethod::Create,
+            let res = reference_integrity_checks_on_create_or_update(
+                CreateOrUpdate::Create,
                 spacetimedb_table,
                 &internal_columns,
-                paths_of_traits_to_extend
+                paths_of_traits_to_extend,
+                (&column_names_and_row_values, None),
             );
             paths_of_traits_to_extend = res.0;
             let reference_integrity_checks = res.1;
@@ -609,16 +680,36 @@ pub(in crate::internal) fn for_method(
                 let #singular_table_name = #struct_name {
                     #(#constructor_arg_names),*
                 };
-                
+
+                let mut #field_name_for_found_value: Option<#struct_name> = None;
+
                 #(#multi_column_index_checks)*
 
                 #(#reference_integrity_checks)*
 
-                self
+                match self
                     .ctx()
                     .db()
                     .#singular_table_name()
-                    .try_insert(#singular_table_name)
+                    .try_insert(#singular_table_name.clone()) {
+                    Ok(entity) => Ok(entity),
+                    Err(error) => match error {
+                        spacetimedb::TryInsertError::UniqueConstraintViolation(_) => {
+                            Err(spacetimedsl::SpacetimeDSLError::UniqueConstraintViolation {
+                                table_name: #singular_table_name_as_string.into(),
+                                action: spacetimedsl::Action::Create,
+                                error_from: spacetimedsl::ErrorFrom::SpacetimeDB,
+                                one_or_multiple: spacetimedsl::OneOrMultiple::One,
+                                column_names_and_row_values: format!("{:?}", #singular_table_name).into(),
+                            })
+                        }
+                        spacetimedb::TryInsertError::AutoIncOverflow(_) => {
+                            Err(spacetimedsl::SpacetimeDSLError::AutoIncOverflow {
+                                table_name: #singular_table_name_as_string.into(),
+                            })
+                        }
+                    },
+                }
             }
         }
         DSLMethod::GetAll => {
@@ -631,7 +722,7 @@ pub(in crate::internal) fn for_method(
             return_type = quote! {
                 impl Iterator<Item = #struct_name>
             };
-            
+
             method_impl = quote! {
                 self
                     .ctx()
@@ -659,9 +750,14 @@ pub(in crate::internal) fn for_method(
                     .count()
             };
         }
-        DSLMethod::GetMany(index) | DSLMethod::DeleteMany(index) | DSLMethod::GetOneOption(index) | DSLMethod::Update(index) | DSLMethod::DeleteOne(index)  => {
+        DSLMethod::GetMany(index)
+        | DSLMethod::DeleteMany(index)
+        | DSLMethod::GetOneOption(index)
+        | DSLMethod::Update(index)
+        | DSLMethod::DeleteOne(index) => {
             let index_name = &index.name;
-            let index_name_pascal_case = RenameRule::PascalCase.apply_to_field(index_name.to_string());
+            let index_name_pascal_case =
+                RenameRule::PascalCase.apply_to_field(index_name.to_string());
 
             let is_unique_index = index.is_unique;
             let is_multi_column_index;
@@ -672,6 +768,8 @@ pub(in crate::internal) fn for_method(
             let index_documentation;
             let mut documentation_on_column_or_columns;
 
+            let mut column_names_and_row_values = String::new();
+            column_names_and_row_values.push_str("{{ ");
             match &index.index_type {
                 IndexType::BTreeSingleColumn { column } => {
                     is_multi_column_index = false;
@@ -680,7 +778,8 @@ pub(in crate::internal) fn for_method(
                     single_or_multi = "single";
                     index_documentation = format!("btree index");
                     documentation_on_column_or_columns = format!("`{column}` column");
-                },
+                    // FIXME: column_names_and_row_values
+                }
                 IndexType::BTreeMultiColumn { columns } => {
                     is_multi_column_index = true;
                     value_matches_or_values_match = "values match the values from";
@@ -692,21 +791,32 @@ pub(in crate::internal) fn for_method(
 
                     let mut columns: VecDeque<Ident> = columns.clone().into();
 
-                    let first_column = columns.pop_front().expect("There should be a first column in Vec<Ident> of BTreeMultiColumn.");
-                    let last_column = columns.pop_back().expect("There should be a last column in Vec<Ident> of BTreeMultiColumn.");
+                    let first_column = columns.pop_front().expect(
+                        "There should be a first column in Vec<Ident> of BTreeMultiColumn.",
+                    );
+                    let last_column = columns
+                        .pop_back()
+                        .expect("There should be a last column in Vec<Ident> of BTreeMultiColumn.");
                     let any_other_column = columns;
-                    
+
                     documentation_on_column_or_columns.push_str(&format!(" `{first_column}`"));
+                    column_names_and_row_values.push_str(&format!("{first_column} : "));
+                    column_names_and_row_values.push_str("{} ");
                     index_columns.push(first_column);
 
                     for any_other_column in any_other_column {
-                        documentation_on_column_or_columns.push_str(&format!(", `{any_other_column}`"));
+                        documentation_on_column_or_columns
+                            .push_str(&format!(", `{any_other_column}`"));
+                        column_names_and_row_values.push_str(&format!(", {any_other_column} : "));
+                        column_names_and_row_values.push_str("{} ");
                         index_columns.push(any_other_column);
                     }
 
                     documentation_on_column_or_columns.push_str(&format!(" and `{last_column}`"));
+                    column_names_and_row_values.push_str(&format!(", {last_column} : "));
+                    column_names_and_row_values.push_str("{}");
                     index_columns.push(last_column);
-                },
+                }
                 IndexType::Direct { column } => {
                     is_multi_column_index = false;
                     index_columns.push(column.clone());
@@ -714,11 +824,13 @@ pub(in crate::internal) fn for_method(
                     single_or_multi = "single";
                     index_documentation = format!("direct index");
                     documentation_on_column_or_columns = format!("`{column}` column");
-                },
+                    // FIXME: column_names_and_row_values
+                }
             };
+            column_names_and_row_values.push_str(" }}");
 
             let unique_multi_column_index_hint;
-            
+
             if is_unique_index && is_multi_column_index {
                 unique_multi_column_index_hint = "Warning: The unique multi-column index feature of SpacetimeDSL is experimental.\n- It will be removed if unique multi-column indices are implemented in SpacetimeDB.\n- SpacetimeDSL is only able to enforce referential integrity if you never use the (mutating) `insert`, `update` and `delete` methods of `spacetimedb::ReducerContext` yourself.";
             } else {
@@ -741,25 +853,49 @@ pub(in crate::internal) fn for_method(
                 DSLMethod::DeleteOne(_) => format!(
                     "{unique_multi_column_index_hint}\n\nTry to delete a `{struct_name}` row in the `{singular_table_name}` table whose {value_matches_or_values_match} the unique {single_or_multi}-column {index_documentation} on the {documentation_on_column_or_columns}."
                 ),
-                DSLMethod::Create | DSLMethod::GetAll | DSLMethod::GetCount=> panic!("DSLColumnMethod Create / GetAll / GetCount should already be processed!"),
+                DSLMethod::Create | DSLMethod::GetAll | DSLMethod::GetCount => panic!(
+                    "DSLColumnMethod Create / GetAll / GetCount should already be processed!"
+                ),
             };
 
             trait_name = match dsl_method {
-                DSLMethod::GetMany(_) => format_ident!("Get{singular_table_name_pascal_case}RowsBy{index_name_pascal_case}"),
-                DSLMethod::DeleteMany(_) => format_ident!("Delete{singular_table_name_pascal_case}RowsBy{index_name_pascal_case}"),
-                DSLMethod::GetOneOption(_) => format_ident!("Get{singular_table_name_pascal_case}RowOptionBy{index_name_pascal_case}"),
-                DSLMethod::Update(_) => format_ident!("Update{singular_table_name_pascal_case}RowBy{index_name_pascal_case}"),
-                DSLMethod::DeleteOne(_) => format_ident!("Delete{singular_table_name_pascal_case}RowBy{index_name_pascal_case}"),
-                DSLMethod::Create | DSLMethod::GetAll | DSLMethod::GetCount=> panic!("DSLColumnMethod Create / GetAll / GetCount should already be processed!"),
+                DSLMethod::GetMany(_) => format_ident!(
+                    "Get{singular_table_name_pascal_case}RowsBy{index_name_pascal_case}"
+                ),
+                DSLMethod::DeleteMany(_) => format_ident!(
+                    "Delete{singular_table_name_pascal_case}RowsBy{index_name_pascal_case}"
+                ),
+                DSLMethod::GetOneOption(_) => format_ident!(
+                    "Get{singular_table_name_pascal_case}RowOptionBy{index_name_pascal_case}"
+                ),
+                DSLMethod::Update(_) => format_ident!(
+                    "Update{singular_table_name_pascal_case}RowBy{index_name_pascal_case}"
+                ),
+                DSLMethod::DeleteOne(_) => format_ident!(
+                    "Delete{singular_table_name_pascal_case}RowBy{index_name_pascal_case}"
+                ),
+                DSLMethod::Create | DSLMethod::GetAll | DSLMethod::GetCount => panic!(
+                    "DSLColumnMethod Create / GetAll / GetCount should already be processed!"
+                ),
             };
 
             method_name = match dsl_method {
                 DSLMethod::GetMany(_) => format_ident!("get_{plural_table_name}_by_{index_name}"),
-                DSLMethod::DeleteMany(_) => format_ident!("delete_{plural_table_name}_by_{index_name}"),
-                DSLMethod::GetOneOption(_) => format_ident!("get_{singular_table_name}_by_{index_name}"),
-                DSLMethod::Update(_) => format_ident!("update_{singular_table_name}_by_{index_name}"),
-                DSLMethod::DeleteOne(_) => format_ident!("delete_{singular_table_name}_by_{index_name}"),
-                DSLMethod::Create | DSLMethod::GetAll | DSLMethod::GetCount=> panic!("DSLColumnMethod Create / GetAll / GetCount should already be processed!"),
+                DSLMethod::DeleteMany(_) => {
+                    format_ident!("delete_{plural_table_name}_by_{index_name}")
+                }
+                DSLMethod::GetOneOption(_) => {
+                    format_ident!("get_{singular_table_name}_by_{index_name}")
+                }
+                DSLMethod::Update(_) => {
+                    format_ident!("update_{singular_table_name}_by_{index_name}")
+                }
+                DSLMethod::DeleteOne(_) => {
+                    format_ident!("delete_{singular_table_name}_by_{index_name}")
+                }
+                DSLMethod::Create | DSLMethod::GetAll | DSLMethod::GetCount => panic!(
+                    "DSLColumnMethod Create / GetAll / GetCount should already be processed!"
+                ),
             };
 
             return_type = match dsl_method {
@@ -767,47 +903,62 @@ pub(in crate::internal) fn for_method(
                     impl Iterator<Item = #struct_name>
                 },
                 DSLMethod::DeleteMany(_) => quote! {
-                    Result<u64, ()>
+                    Result<spacetimedsl::DeletionResult, spacetimedsl::SpacetimeDSLError>
                 },
                 DSLMethod::GetOneOption(_) => quote! {
-                    Option<#struct_name>
+                    Result<#struct_name, spacetimedsl::SpacetimeDSLError>
                 },
                 DSLMethod::Update(_) => quote! {
-                    Result<#struct_name, spacetimedb::TryInsertError<#try_insert_error_generic_type>>
+                    Result<#struct_name, spacetimedsl::SpacetimeDSLError>
                 },
                 DSLMethod::DeleteOne(_) => quote! {
-                    Result<bool, ()>
+                    Result<spacetimedsl::DeletionResult, spacetimedsl::SpacetimeDSLError>
                 },
-                DSLMethod::Create | DSLMethod::GetAll | DSLMethod::GetCount=> panic!("DSLColumnMethod Create / GetAll / GetCount should already be processed!"),
+                DSLMethod::Create | DSLMethod::GetAll | DSLMethod::GetCount => panic!(
+                    "DSLColumnMethod Create / GetAll / GetCount should already be processed!"
+                ),
             };
 
             match dsl_method {
                 DSLMethod::Update(_) => {
-                    method_args.push(
-                        SpacetimeDSLMethodArg {
-                            is_mut: true,
-                            arg_name: singular_table_name.clone(),
-                            arg_type: quote! { #struct_name }
-                        }
-                    );
-                
+                    method_args.push(SpacetimeDSLMethodArg {
+                        is_mut: true,
+                        arg_name: singular_table_name.clone(),
+                        arg_type: quote! { #struct_name },
+                    });
+
                     let multi_column_index_checks = multi_column_index_checks(
+                        Action::Update,
                         &struct_name,
                         &singular_table_name,
                         &spacetimedb_table,
                         &primary_key_column_name,
+                        &column_names_and_row_values,
                     );
-                            
-                    let mut column_getters = vec![];
-                
-                    internal_columns.iter().filter(|internal_column| internal_column.spacetimedsl_column_foreign_key.is_some() && internal_column.rust_field_visibility.to_string().ne(&RustVisibility::Private.to_string())).for_each(|internal_column| {
-                        let (_, _, column_getter, _) = process_columns_for_create_and_update_method(CreateOrUpdateDSLMethod::Update, &internal_column);
-                        match column_getter {
-                            Some(column_getter) => column_getters.push(column_getter),
-                            None => {},
-                        };
-                    });
-                            
+
+                    let mut row_value_getters = vec![];
+
+                    internal_columns
+                        .iter()
+                        .filter(|internal_column| {
+                            internal_column.spacetimedsl_column_foreign_key.is_some()
+                                && internal_column
+                                    .rust_field_visibility
+                                    .to_string()
+                                    .ne(&RustVisibility::Private.to_string())
+                        })
+                        .for_each(|internal_column| {
+                            let (_, _, column_getter, _) =
+                                process_columns_for_create_and_update_method(
+                                    CreateOrUpdate::Update,
+                                    &internal_column,
+                                );
+                            match column_getter {
+                                Some(column_getter) => row_value_getters.push(column_getter),
+                                None => {}
+                            };
+                        });
+
                     // TODO: https://github.com/tamaro-skaljic/SpacetimeDSL/issues/37
                     let modified_at = match spacetimedsl_table.has_modified_at_column {
                         false => TokenStream::default(),
@@ -817,7 +968,7 @@ pub(in crate::internal) fn for_method(
                             }
                         }
                     };
-                    
+
                     let use_itertools = if multi_column_index_checks.len() > 0 {
                         quote! {
                             use spacetimedsl::itertools::Itertools;
@@ -825,31 +976,36 @@ pub(in crate::internal) fn for_method(
                     } else {
                         TokenStream::default()
                     };
-                    
-                    let res = reference_integrity_checks(
-                        CreateOrUpdateDSLMethod::Update,
+
+                    let res = reference_integrity_checks_on_create_or_update(
+                        CreateOrUpdate::Update,
                         spacetimedb_table,
                         internal_columns,
-                        paths_of_traits_to_extend
+                        paths_of_traits_to_extend,
+                        (&column_names_and_row_values, Some(&row_value_getters)),
                     );
                     paths_of_traits_to_extend = res.0;
                     let reference_integrity_checks = res.1;
-                    
+
                     let index_name = match is_multi_column_index {
                         true => primary_key_column_name,
                         false => index_name,
                     };
-                    
+
                     method_impl = quote! {
                         #use_itertools
-                        
+
+                        let mut #field_name_for_found_value: Option<#struct_name> = None;
+
                         #(#multi_column_index_checks)*
-                        
-                        #(#column_getters)*
+
+                        #(#row_value_getters)*
                         #(#reference_integrity_checks)*
-                        
+
                         #modified_at
-                        
+
+                        // FIXME: try_update instead of update
+                        // FIXME: on error return Err(spacetimedsl::SpacetimeDSLError);
                         Ok(self
                             .ctx()
                             .db()
@@ -858,14 +1014,18 @@ pub(in crate::internal) fn for_method(
                             .update(#singular_table_name)
                         )
                     };
-                },
+                }
                 dsl_method => {
                     let mut wrapper_type_option_to_wrapped_type_option_mappers = vec![];
-                    let mut column_value_getters = vec![];
+                    let mut row_value_getters = vec![];
 
                     for column in internal_columns {
                         let column_name = &column.rust_field_name;
-                        let column_is_string = column.rust_field_type_name_or_path.to_token_stream().to_string().eq(&"String");
+                        let column_is_string = column
+                            .rust_field_type_name_or_path
+                            .to_token_stream()
+                            .to_string()
+                            .eq(&"String");
 
                         if !&index_columns.contains(&column_name) {
                             continue;
@@ -873,7 +1033,7 @@ pub(in crate::internal) fn for_method(
 
                         let wrapper_type_option_to_wrapped_type_option_mapper;
                         let method_arg;
-                        let column_value_getter;
+                        let row_value_getter;
 
                         match &column.spacetimedsl_column_wrapper_type {
                             Some(wrapper_type) => {
@@ -881,29 +1041,36 @@ pub(in crate::internal) fn for_method(
 
                                 // TODO: string stuff was only in the single column index implementation, does that work for multi column indices?
                                 if column_is_string {
-                                    wrapper_type_option_to_wrapped_type_option_mapper = TokenStream::default();
+                                    wrapper_type_option_to_wrapped_type_option_mapper =
+                                        TokenStream::default();
 
                                     match &dsl_method {
                                         DSLMethod::GetMany(_) | DSLMethod::DeleteMany(_) => {
                                             method_arg = SpacetimeDSLMethodArg {
                                                 is_mut: false,
                                                 arg_name: column_name.clone(),
-                                                arg_type: quote! { &str }
+                                                arg_type: quote! { &str },
                                             };
-                                            column_value_getter = quote! { #column_name };
+                                            row_value_getter = quote! { #column_name };
                                         }
                                         DSLMethod::GetOneOption(_) | DSLMethod::DeleteOne(_) => {
                                             method_arg = SpacetimeDSLMethodArg {
                                                 is_mut: false,
                                                 arg_name: column_name.clone(),
-                                                arg_type: quote! { &str }
+                                                arg_type: quote! { &str },
                                             };
-                                            column_value_getter = quote! { #column_name.to_string() };
+                                            row_value_getter = quote! { #column_name.to_string() };
                                         }
                                         DSLMethod::Update(_) => {
-                                            panic!("DSLColumnMethod::Update should already be processed!")
+                                            panic!(
+                                                "DSLColumnMethod::Update should already be processed!"
+                                            )
                                         }
-                                        DSLMethod::Create | DSLMethod::GetAll | DSLMethod::GetCount=> panic!("DSLColumnMethod Create / GetAll / GetCount should already be processed!"),
+                                        DSLMethod::Create
+                                        | DSLMethod::GetAll
+                                        | DSLMethod::GetCount => panic!(
+                                            "DSLColumnMethod Create / GetAll / GetCount should already be processed!"
+                                        ),
                                     }
                                 } else if column.spacetimedsl_column_is_option {
                                     wrapper_type_option_to_wrapped_type_option_mapper = quote! {
@@ -912,49 +1079,60 @@ pub(in crate::internal) fn for_method(
                                             Some(#column_name) => Some(Into::<#wrapper_type>::into(#column_name).value());
                                         }
                                     };
-                                    
+
                                     method_arg = SpacetimeDSLMethodArg {
                                         is_mut: false,
                                         arg_name: column_name.clone(),
-                                        arg_type: quote! { &impl Into<Option<#wrapper_type>> }
+                                        arg_type: quote! { &impl Into<Option<#wrapper_type>> },
                                     };
 
-                                    column_value_getter = quote! { #column_name };
+                                    row_value_getter = quote! { #column_name };
                                 } else {
-                                    wrapper_type_option_to_wrapped_type_option_mapper = TokenStream::default();
+                                    wrapper_type_option_to_wrapped_type_option_mapper =
+                                        TokenStream::default();
 
                                     match &dsl_method {
                                         DSLMethod::GetMany(_) | DSLMethod::DeleteMany(_) => {
                                             method_arg = SpacetimeDSLMethodArg {
                                                 is_mut: false,
                                                 arg_name: column_name.clone(),
-                                                arg_type: quote! { impl Into<#wrapper_type> }
+                                                arg_type: quote! { impl Into<#wrapper_type> },
                                             };
-                                            column_value_getter = quote! { #column_name.into().value() };
+                                            row_value_getter =
+                                                quote! { #column_name.into().value() };
                                         }
                                         DSLMethod::GetOneOption(_) | DSLMethod::DeleteOne(_) => {
                                             method_arg = SpacetimeDSLMethodArg {
                                                 is_mut: false,
                                                 arg_name: column_name.clone(),
-                                                arg_type: quote! { impl Into<#wrapper_type> + Clone }
+                                                arg_type: quote! { impl Into<#wrapper_type> + Clone },
                                             };
-                                            column_value_getter = quote! { #column_name.clone().into().value() };
+                                            row_value_getter =
+                                                quote! { #column_name.clone().into().value() };
                                         }
                                         DSLMethod::Update(_) => {
-                                            panic!("DSLColumnMethod::Update should already be processed!")
+                                            panic!(
+                                                "DSLColumnMethod::Update should already be processed!"
+                                            )
                                         }
-                                        DSLMethod::Create | DSLMethod::GetAll | DSLMethod::GetCount=> panic!("DSLColumnMethod Create / GetAll / GetCount should already be processed!"),
+                                        DSLMethod::Create
+                                        | DSLMethod::GetAll
+                                        | DSLMethod::GetCount => panic!(
+                                            "DSLColumnMethod Create / GetAll / GetCount should already be processed!"
+                                        ),
                                     }
                                 }
-                            },
+                            }
                             None => {
-                                wrapper_type_option_to_wrapped_type_option_mapper = TokenStream::default();
+                                wrapper_type_option_to_wrapped_type_option_mapper =
+                                    TokenStream::default();
 
                                 let column_type;
 
                                 // TODO: string stuff was only in the single column index implementation, does that work for multi column indices?
                                 if column_is_string {
-                                    column_type = parse_str("str").expect("parsing should have worked");
+                                    column_type =
+                                        parse_str("str").expect("parsing should have worked");
                                 } else {
                                     column_type = column.rust_field_type_name_or_path.clone();
                                 }
@@ -964,40 +1142,47 @@ pub(in crate::internal) fn for_method(
                                         method_arg = SpacetimeDSLMethodArg {
                                             is_mut: false,
                                             arg_name: column_name.clone(),
-                                            arg_type: quote! { &'a #column_type }
+                                            arg_type: quote! { &'a #column_type },
                                         };
-                                        
-                                        column_value_getter = quote! { #column_name };
+
+                                        row_value_getter = quote! { #column_name };
                                     }
                                     DSLMethod::GetOneOption(_) | DSLMethod::DeleteOne(_) => {
                                         method_arg = SpacetimeDSLMethodArg {
                                             is_mut: false,
                                             arg_name: column_name.clone(),
-                                            arg_type: quote! { &#column_type }
+                                            arg_type: quote! { &#column_type },
                                         };
 
                                         // TODO: string stuff was only in the single column index implementation, does that work for multi column indices?
                                         // TODO: Does that String stuff also work for GetMany and DeleteMany?
                                         if column_is_string {
-                                            column_value_getter = quote! { #column_name.to_string() };
+                                            row_value_getter = quote! { #column_name.to_string() };
                                         } else {
-                                            column_value_getter = quote! { #column_name };
+                                            row_value_getter = quote! { #column_name };
                                         }
                                     }
                                     DSLMethod::Update(_) => {
-                                        panic!("DSLColumnMethod::Update should already be processed!")
+                                        panic!(
+                                            "DSLColumnMethod::Update should already be processed!"
+                                        )
                                     }
-                                    DSLMethod::Create | DSLMethod::GetAll | DSLMethod::GetCount=> panic!("DSLColumnMethod Create / GetAll / GetCount should already be processed!"),
+                                    DSLMethod::Create | DSLMethod::GetAll | DSLMethod::GetCount => {
+                                        panic!(
+                                            "DSLColumnMethod Create / GetAll / GetCount should already be processed!"
+                                        )
+                                    }
                                 }
-                            },
+                            }
                         }
-                        
-                        wrapper_type_option_to_wrapped_type_option_mappers.push(wrapper_type_option_to_wrapped_type_option_mapper);
+
+                        wrapper_type_option_to_wrapped_type_option_mappers
+                            .push(wrapper_type_option_to_wrapped_type_option_mapper);
                         method_args.push(method_arg);
-                        column_value_getters.push(column_value_getter);
+                        row_value_getters.push(row_value_getter);
                     }
 
-                    let method_impl_prefix= quote! {
+                    let method_impl_prefix = quote! {
                         self
                             .ctx()
                             .db()
@@ -1005,238 +1190,371 @@ pub(in crate::internal) fn for_method(
                             .#index_name()
                     };
 
-                    method_impl = match dsl_method {
-                        DSLMethod::GetMany(_) => {
-                            match is_multi_column_index {
-                                true => quote! {
+                    match dsl_method {
+                        DSLMethod::GetMany(_) => match is_multi_column_index {
+                            true => {
+                                method_impl = quote! {
                                     #(#wrapper_type_option_to_wrapped_type_option_mappers)*
 
                                     #method_impl_prefix
-                                        .filter((#(#column_value_getters),*))
-                                },
-                                false => quote! {
+                                        .filter((#(#row_value_getters),*))
+                                }
+                            }
+                            false => {
+                                method_impl = quote! {
                                     #(#wrapper_type_option_to_wrapped_type_option_mappers)*
 
                                     #method_impl_prefix
-                                        .filter(#(#column_value_getters),*)
+                                        .filter(#(#row_value_getters),*)
                                 }
                             }
                         },
                         DSLMethod::DeleteMany(_) => {
-                            if spacetimedsl_table.referencing_tables.is_empty() {
-                                match is_multi_column_index {
-                                    true => quote! {
-                                        #(#wrapper_type_option_to_wrapped_type_option_mappers)*
+                            let let_index_name = match is_multi_column_index {
+                                true => quote! {
+                                    let #index_name = (#(#row_value_getters),*);
+                                },
+                                false => quote! {
+                                    let #index_name = #(#row_value_getters),*;
+                                },
+                            };
 
-                                        Ok(#method_impl_prefix
-                                            .delete((#(#column_value_getters),*))
-                                        )
-                                    },
-                                    false => quote! {
-                                        #(#wrapper_type_option_to_wrapped_type_option_mappers)*
+                            let impl_until_return_ok_on_is_empty = quote! {
+                                use itertools::Itertools;
 
-                                        Ok(#method_impl_prefix
-                                            .delete(#(#column_value_getters),*)
-                                        )
-                                    }
+                                #(#wrapper_type_option_to_wrapped_type_option_mappers)*
+
+                                #let_index_name
+
+                                let primary_key_column_values_of_referencing_table = #method_impl_prefix
+                                    .filter(#index_name)
+                                    .map(|row| row.#primary_key_column_name)
+                                    .collect();
+
+                                if primary_key_column_values_of_referencing_table.is_empty() {
+                                    return Ok(spacetimedsl::DeletionResult {
+                                        table_name: #singular_table_name_as_string.into(),
+                                        one_or_multiple: spacetimedsl::OneOrMultiple::Multiple,
+                                        entries: vec![],
+                                    });
                                 }
+                            };
+
+                            let map_primary_key_column_values_of_referencing_table_to_deletion_result_entries = quote! {
+                                let mut entries = std::collections::HashMap::new();
+
+                                for primary_key_column_value_of_referencing_table in &primary_key_column_values_of_referencing_table {
+                                    entries.insert(
+                                        primary_key_column_value_of_referencing_table,
+                                        spacetimedsl::DeletionResultEntry {
+                                            table_name: #singular_table_name_as_string.into(),
+                                            column_name: "id".into(),
+                                            strategy: spacetimedsl::OnDeleteStrategy::Delete,
+                                            row_value: format!("{primary_key_column_value_of_referencing_table}").into(),
+                                            child_entries: vec![],
+                                        }
+                                    );
+                                }
+                            };
+
+                            let delete_many_and_return_result_impl = quote! {
+                                let count_of_rows_to_delete = primary_key_column_values_of_referencing_table.len();
+                                let count_of_deleted_rows = #method_impl_prefix.delete(#index_name);
+
+                                if count_of_rows_to_delete.ne(&count_of_deleted_rows) {
+                                    return Err(
+                                        spacetimedsl::SpacetimeDSLError::Error(
+                                            format!(
+                                                "Delete Many Error: `count_of_rows_to_delete ( {} ) != ( {} ) count_of_deleted_rows`!",
+                                                &count_of_rows_to_delete,
+                                                &count_of_deleted_rows
+                                            )
+                                        )
+                                    );
+                                }
+
+                                return Ok(spacetimedsl::DeletionResult {
+                                    table_name: #singular_table_name_as_string.into(),
+                                    one_or_multiple: spacetimedsl::OneOrMultiple::Multiple,
+                                    entries: entries.into_values().collect_vec(),
+                                });
+                            };
+
+                            if spacetimedsl_table.referencing_tables.is_empty() {
+                                method_impl = quote! {
+                                    #impl_until_return_ok_on_is_empty
+
+                                    #map_primary_key_column_values_of_referencing_table_to_deletion_result_entries
+
+                                    #delete_many_and_return_result_impl
+                                };
                             } else {
                                 let referenced_table_function_name = get_referenced_table_function_name(
                                     &DSLInternalReferencedByFunction::ExecuteOnDeleteStrategiesOfReferencingTablesAfterMultipleRowsOfThisTableWereDeleted,
                                     &singular_table_name
                                 );
-                                
-                                let primary_key_column = internal_columns
-                                    .iter()
-                                    .find(|c| c.rust_field_name.eq(primary_key_column_name))
-                                    .expect("should have a primary key");
 
-                                let primary_key_column_type = &primary_key_column.rust_field_type_name_or_path;
+                                method_impl = quote! {
+                                    #impl_until_return_ok_on_is_empty
 
-                                match is_multi_column_index {
-                                    true => quote! {
-                                        #(#wrapper_type_option_to_wrapped_type_option_mappers)*
-                                        
-                                        let #index_name = (#(#column_value_getters),*);
+                                    #map_primary_key_column_values_of_referencing_table_to_deletion_result_entries
 
-                                        let pk_values_of_rows_to_delete: Vec<#primary_key_column_type> = #method_impl_prefix
-                                            .filter(#index_name)
-                                            .map(|row| row.#primary_key_column_name)
-                                            .collect();
+                                    match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::Error, entries) {
+                                        Err(e) => {
+                                            return Err(spacetimedsl::DeletionResult {
+                                                table_name: #singular_table_name_as_string.into(),
+                                                one_or_multiple: spacetimedsl::OneOrMultiple::Multiple,
+                                                entries: e.into_values().collect_vec(),
+                                            });
+                                        },
+                                        Ok(e) => entries = e,
+                                    };
 
-                                        if pk_values_of_rows_to_delete.is_empty() {
-                                            return Ok(0);
-                                        }
+                                    match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::Delete, entries) {
+                                        Err(e) => {
+                                            return Err(spacetimedsl::DeletionResult {
+                                                table_name: #singular_table_name_as_string.into(),
+                                                one_or_multiple: spacetimedsl::OneOrMultiple::Multiple,
+                                                entries: e.into_values().collect_vec(),
+                                            });
+                                        },
+                                        Ok(e) => entries = e,
+                                    };
 
-                                        spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::Error, &pk_values_of_rows_to_delete)?;
-                                        spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::Delete, &pk_values_of_rows_to_delete)?;
-                                        //TODO: spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::SetNone, &pk_values_of_rows_to_delete)?;
-                                        spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::SetZero, &pk_values_of_rows_to_delete)?;
-                                        
-                                        Ok(
-                                            #method_impl_prefix
-                                                .delete(#index_name)
-                                        )
-                                    },
-                                    false => quote! {
-                                        #(#wrapper_type_option_to_wrapped_type_option_mappers)*
+                                    /* // FIXME: If SetNone is implemented
+                                    match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::SetNone, entry) {
+                                        Err(e) => {
+                                            return Err(spacetimedsl::DeletionResult {
+                                                table_name: #singular_table_name_as_string.into(),
+                                                one_or_multiple: spacetimedsl::OneOrMultiple::Multiple,
+                                                entries: e.into_values().collect_vec(),
+                                            });
+                                        },
+                                        Ok(e) => entries = e,
+                                    };
+                                    */
 
-                                        let #index_name = #(#column_value_getters),*;
+                                    match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::SetZero, entries) {
+                                        Err(e) => {
+                                            return Err(spacetimedsl::DeletionResult {
+                                                table_name: #singular_table_name_as_string.into(),
+                                                one_or_multiple: spacetimedsl::OneOrMultiple::Multiple,
+                                                entries: e.into_values().collect_vec(),
+                                            });
+                                        },
+                                        Ok(e) => entries = e,
+                                    };
 
-                                        let pk_values_of_rows_to_delete: Vec<#primary_key_column_type> = #method_impl_prefix
-                                            .filter(#index_name.clone())
-                                            .map(|row| row.#primary_key_column_name)
-                                            .collect();
-
-                                        if pk_values_of_rows_to_delete.is_empty() {
-                                            return Ok(0);
-                                        }
-
-                                        spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::Error, &pk_values_of_rows_to_delete)?;
-                                        spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::Delete, &pk_values_of_rows_to_delete)?;
-                                        //TODO: spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::SetNone, &pk_values_of_rows_to_delete)?;
-                                        spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::SetZero, &pk_values_of_rows_to_delete)?;
-
-                                        Ok(
-                                            #method_impl_prefix
-                                                .delete(#index_name)
-                                        )
-                                    }
-                                }
-
-                                
+                                    #delete_many_and_return_result_impl
+                                };
                             }
-                        },
-                        DSLMethod::GetOneOption(_) => {
-                            match is_multi_column_index {
-                                true => {
-                                    let multi_column_index_check = get_unique_multi_column_index_check(
-                                        &struct_name,
-                                        &singular_table_name,
-                                        &index_name,
-                                        &column_value_getters,
-                                    )
-                                    .check;
+                        }
+                        DSLMethod::GetOneOption(_) => match is_multi_column_index {
+                            true => {
+                                let multi_column_index_check = get_unique_multi_column_index_check(
+                                    &Action::Get,
+                                    &singular_table_name,
+                                    &index_name,
+                                    &column_names_and_row_values,
+                                    &row_value_getters,
+                                );
 
-                                    quote! {
-                                        #(#wrapper_type_option_to_wrapped_type_option_mappers)*
-
-                                        use spacetimedsl::itertools::Itertools;
-
-                                        #multi_column_index_check
-
-                                        #field_name_for_found_value
-                                    }
-                                },
-                                false => quote! {
+                                method_impl = quote! {
                                     #(#wrapper_type_option_to_wrapped_type_option_mappers)*
-                                    
-                                    #method_impl_prefix
-                                        .find(#(#column_value_getters),*)
+
+                                    use spacetimedsl::itertools::Itertools;
+
+                                    let mut #field_name_for_found_value: Option<#struct_name> = None;
+
+                                    #multi_column_index_check
+
+                                    match #field_name_for_found_value {
+                                        Some(#singular_table_name) => Ok(#singular_table_name),
+                                        None => {
+                                            return Err(
+                                                spacetimedsl::SpacetimeDSLError::NotFoundError {
+                                                    table_name: #singular_table_name_as_string,
+                                                    column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*)
+                                                }
+                                            );
+                                        }
+                                    };
+                                };
+                            }
+                            false => {
+                                method_impl = quote! {
+                                    #(#wrapper_type_option_to_wrapped_type_option_mappers)*
+
+                                    match #method_impl_prefix.find(#(#row_value_getters),*) {
+                                        Some(#singular_table_name) => Ok(#singular_table_name),
+                                        None => return Err(
+                                            spacetimedsl::SpacetimeDSLError::NotFoundError {
+                                                table_name: #singular_table_name_as_string,
+                                                column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*)
+                                            }
+                                        )
+                                    };
                                 }
                             }
                         },
                         DSLMethod::DeleteOne(_) => {
-
-                            let multi_column_index_check = get_unique_multi_column_index_check(
-                                &struct_name,
-                                &singular_table_name,
-                                &index_name,
-                                &column_value_getters,
-                            )
-                            .check;
-
-                            if spacetimedsl_table.referencing_tables.is_empty() {
+                            let get_primary_key_column_value_of_referencing_table =
                                 match is_multi_column_index {
                                     true => {
-                                        quote! {
-                                            #(#wrapper_type_option_to_wrapped_type_option_mappers)*
+                                        let multi_column_index_check =
+                                            get_unique_multi_column_index_check(
+                                                &Action::Delete,
+                                                &singular_table_name,
+                                                &index_name,
+                                                &column_names_and_row_values,
+                                                &row_value_getters,
+                                            );
 
+                                        quote! {
                                             use spacetimedsl::itertools::Itertools;
+
+                                            let #index_name = (#(#row_value_getters),*);
+
+                                            let mut #field_name_for_found_value: Option<#struct_name> = None;
 
                                             #multi_column_index_check
 
-                                            Ok(
-                                                self
-                                                    .ctx()
-                                                    .db()
-                                                    .#singular_table_name()
-                                                    .#primary_key_column_name()
-                                                    .delete(#field_name_for_found_value.expect("value should be found").#primary_key_column_name)
-                                            )
+                                            let primary_key_column_value_of_referencing_table = #field_name_for_found_value;
                                         }
-                                    },
-                                    false => quote! {
-                                        #(#wrapper_type_option_to_wrapped_type_option_mappers)*
-                                        Ok(
-                                            #method_impl_prefix
-                                                .delete(#(#column_value_getters),*)
-                                        )
                                     }
-                                }
+                                    false => quote! {
+                                        let #index_name = #(#row_value_getters),*;
+
+                                        let primary_key_column_value_of_referencing_table = #method_impl_prefix.find(#index_name);
+                                    },
+                                };
+
+                            let impl_until_return_err_on_is_none = quote! {
+                                use itertools::Itertools;
+
+                                #(#wrapper_type_option_to_wrapped_type_option_mappers)*
+
+                                #get_primary_key_column_value_of_referencing_table
+
+                                let primary_key_column_value_of_referencing_table = match primary_key_column_value_of_referencing_table {
+                                    None => return Err(spacetimedsl::DeletionResult {
+                                        table_name: #singular_table_name_as_string.into(),
+                                        one_or_multiple: spacetimedsl::OneOrMultiple::One,
+                                        entries: vec![],
+                                    }),
+                                    Some(primary_key_column_value_of_referencing_table) => primary_key_column_value_of_referencing_table,
+                                };
+                            };
+
+                            let map_primary_key_column_value_of_referencing_table_to_deletion_result_entry = quote! {
+                                let mut entry = (&primary_key_column_value_of_referencing_table, spacetimedsl::DeletionResultEntry {
+                                    table_name: #singular_table_name_as_string.into(),
+                                    column_name: "id".into(),
+                                    strategy: spacetimedsl::OnDeleteStrategy::Delete,
+                                    row_value: format!("{primary_key_column_value_of_referencing_table}").into(),
+                                    child_entries: vec![],
+                                });
+                            };
+
+                            let delete_one_and_return_result_impl = quote! {
+                                match self
+                                        .ctx()
+                                        .db()
+                                        .#singular_table_name()
+                                        .#primary_key_column_name()
+                                        .delete(primary_key_column_value_of_referencing_table) {
+                                    false => {
+                                        return Err(
+                                            spacetimedsl::SpacetimeDSLError::Error(
+                                                "Delete One Error: `count_of_rows_to_delete ( 1 ) != ( 0 ) count_of_deleted_rows`!".to_string(),
+                                            )
+                                        );
+                                    },
+                                    true => {
+                                        return Ok(spacetimedsl::DeletionResult {
+                                            table_name: #singular_table_name_as_string.into(),
+                                            one_or_multiple: spacetimedsl::OneOrMultiple::One,
+                                            entries = vec![entry],
+                                        });
+                                    },
+                                };
+                            };
+
+                            if spacetimedsl_table.referencing_tables.is_empty() {
+                                method_impl = quote! {
+                                    #impl_until_return_err_on_is_none
+
+                                    #map_primary_key_column_value_of_referencing_table_to_deletion_result_entry
+
+                                    #delete_one_and_return_result_impl
+                                };
                             } else {
                                 let referenced_table_function_name = get_referenced_table_function_name(
                                     &DSLInternalReferencedByFunction::ExecuteOnDeleteStrategiesOfReferencingTablesAfterOneRowOfThisTableWasDeleted,
                                     &singular_table_name
                                 );
 
-                                match is_multi_column_index {
-                                    true => {
-                                        quote! {
-                                            #(#wrapper_type_option_to_wrapped_type_option_mappers)*
+                                method_impl = quote! {
+                                    #impl_until_return_err_on_is_none
 
-                                            let #index_name = (#(#column_value_getters),*);
+                                    #map_primary_key_column_value_of_referencing_table_to_deletion_result_entry
 
-                                            let row_to_delete = #method_impl_prefix
-                                                .find(#index_name);
+                                    match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::Error, entry) {
+                                        Err(e) => {
+                                            return Err(spacetimedsl::DeletionResult {
+                                                table_name: #singular_table_name_as_string.into(),
+                                                one_or_multiple: spacetimedsl::OneOrMultiple::One,
+                                                entries: vec![entry],
+                                            });
+                                        },
+                                        Ok(e) => entry = e,
+                                    };
 
-                                            let primary_key_value_of_row_to_delete;
+                                    match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::Delete, entry) {
+                                        Err(e) => {
+                                            return Err(spacetimedsl::DeletionResult {
+                                                table_name: #singular_table_name_as_string.into(),
+                                                one_or_multiple: spacetimedsl::OneOrMultiple::One,
+                                                entries: vec![entry],
+                                            });
+                                        },
+                                        Ok(e) => entry = e,
+                                    };
 
-                                            match row_to_delete {
-                                                None => { return Ok(false); },
-                                                Some(row) => { primary_key_value_of_row_to_delete = row.#primary_key_column_name; },
-                                            };
+                                    /* // FIXME: If SetNone is implemented
+                                    match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::SetNone, entry) {
+                                        Err(e) => {
+                                            return Err(spacetimedsl::DeletionResult {
+                                                table_name: #singular_table_name_as_string.into(),
+                                                one_or_multiple: spacetimedsl::OneOrMultiple::One,
+                                                entries: vec![entry],
+                                            });
+                                        },
+                                        Ok(e) => entry = e,
+                                    };
+                                    */
 
-                                            spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::Error, &primary_key_value_of_row_to_delete)?;
-                                            spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::Delete, &primary_key_value_of_row_to_delete)?;
-                                            //TODO: spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::SetNone, &primary_key_value_of_row_to_delete)?;
-                                            spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::SetZero, &primary_key_value_of_row_to_delete)?;
-                                            
-                                            Ok(
-                                                #method_impl_prefix
-                                                    .delete(#index_name)
-                                            )
-                                        }
-                                    },
-                                    false => quote! {
-                                        #(#wrapper_type_option_to_wrapped_type_option_mappers)*
+                                    match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::SetZero, entry) {
+                                        Err(e) => {
+                                            return Err(spacetimedsl::DeletionResult {
+                                                table_name: #singular_table_name_as_string.into(),
+                                                one_or_multiple: spacetimedsl::OneOrMultiple::One,
+                                                entries: vec![entry],
+                                            });
+                                        },
+                                        Ok(e) => entry = e,
+                                    };
 
-                                        let #index_name = #(#column_value_getters),*;
-
-                                        let row_to_delete = #method_impl_prefix
-                                            .find(#index_name.clone());
-
-                                        let primary_key_value_of_row_to_delete;
-
-                                        match row_to_delete {
-                                            None => { return Ok(false); },
-                                            Some(row) => { primary_key_value_of_row_to_delete = row.#primary_key_column_name; },
-                                        };
-
-                                        spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::Error, &primary_key_value_of_row_to_delete)?;
-                                        spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::Delete, &primary_key_value_of_row_to_delete)?;
-                                        //TODO: spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::SetNone, &primary_key_value_of_row_to_delete)?;
-                                        spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::SetZero, &primary_key_value_of_row_to_delete)?;
-
-                                        Ok(
-                                            #method_impl_prefix
-                                                .delete(#index_name)
-                                        )
-                                    }
-                                }
+                                    #delete_one_and_return_result_impl
+                                };
                             }
-                        },
-                        DSLMethod::Create | DSLMethod::GetAll | DSLMethod::GetCount | DSLMethod::Update(_)=> panic!("DSLColumnMethod Create / GetAll / GetCount / Update should already be processed!"),
+                        }
+                        DSLMethod::Create
+                        | DSLMethod::GetAll
+                        | DSLMethod::GetCount
+                        | DSLMethod::Update(_) => panic!(
+                            "DSLColumnMethod Create / GetAll / GetCount / Update should already be processed!"
+                        ),
                     };
                 }
             };
@@ -1254,19 +1572,26 @@ pub(in crate::internal) fn for_method(
     }
 }
 
-fn reference_integrity_checks(
-    create_or_update_dsl_method: CreateOrUpdateDSLMethod,
+fn reference_integrity_checks_on_create_or_update(
+    create_or_update_dsl_method: CreateOrUpdate,
     spacetimedb_table: &SpacetimeDBTable,
     columns: &Vec<InternalColumn>,
     mut paths_of_traits_to_extend: Vec<Path>,
+    column_names_and_row_value_getters: (&String, Option<&Vec<TokenStream>>),
 ) -> (Vec<Path>, Vec<TokenStream>) {
     let mut reference_integrity_checks = vec![];
 
-    let reasons = "There can be two reasons for this: You are inserting or updating somewhere using spacetimedb::ReducerContext instead of spacetimedsl::DSL or the Foreign Key / Referenced By SpacetimeDSL feature is broken.";
+    let column_names_and_row_values = column_names_and_row_value_getters.0;
+    let row_value_getters = column_names_and_row_value_getters.1;
 
     for column in columns {
         // Checks of private columns only need to happen in checks for create methods, because they can't be changed, they don't need to be checked during updates
-        if create_or_update_dsl_method.eq(&CreateOrUpdateDSLMethod::Update) && column.rust_field_visibility.to_string().eq(&crate::api::rust::visibility::RustVisibility::Private.to_string()) {
+        if create_or_update_dsl_method.eq(&CreateOrUpdate::Update)
+            && column
+                .rust_field_visibility
+                .to_string()
+                .eq(&crate::api::rust::visibility::RustVisibility::Private.to_string())
+        {
             continue;
         }
 
@@ -1278,45 +1603,100 @@ fn reference_integrity_checks(
         };
 
         let referenced_table_name = &foreign_key.table_name;
-        let referenced_table_name_pascal_case = format_ident!("{}", RenameRule::PascalCase.apply_to_field(referenced_table_name.to_string()));
+        let referenced_table_name_pascal_case = format_ident!(
+            "{}",
+            RenameRule::PascalCase.apply_to_field(referenced_table_name.to_string())
+        );
         let referenced_table_primary_key_column_name_pascal_case = format_ident!("Id");
-        let get_row_of_referenced_table_by_primary_key_trait_name = format_ident!("Get{referenced_table_name_pascal_case}RowOptionBy{referenced_table_primary_key_column_name_pascal_case}");
-        let get_row_of_referenced_table_by_primary_key_method_name = format_ident!("get_{referenced_table_name}_by_id");
+        let get_row_of_referenced_table_by_primary_key_trait_name = format_ident!(
+            "Get{referenced_table_name_pascal_case}RowOptionBy{referenced_table_primary_key_column_name_pascal_case}"
+        );
+        let get_row_of_referenced_table_by_primary_key_method_name =
+            format_ident!("get_{referenced_table_name}_by_id");
 
         let referencing_table_name = &spacetimedb_table.singular_name;
+        let referencing_table_name_as_string = referencing_table_name.to_string();
         let referencing_table_column_name = &column.rust_field_name;
-        let referencing_table_column_getter_name = format_ident!("get_{referencing_table_column_name}");
+        let referencing_table_column_getter_name =
+            format_ident!("get_{referencing_table_column_name}");
 
-        let mut reference_integrity_violation_error_panic_message = format!(
-            "There must be a row inside the `{referenced_table_name}` table when trying to find one with primary key column `id` value "
+        let referencing_table_column_type = column
+            .rust_field_type_name_or_path
+            .to_token_stream()
+            .to_string();
+
+        paths_of_traits_to_extend.push(
+            parse_str(&format!(
+                "{}::{get_row_of_referenced_table_by_primary_key_trait_name}",
+                &foreign_key.path.to_token_stream().to_string()
+            ))
+            .expect("should be parseable"),
         );
-        reference_integrity_violation_error_panic_message.push_str("`{:?}`. Found none. ");
-        reference_integrity_violation_error_panic_message.push_str(reasons);
 
-        let referencing_table_column_type = column.rust_field_type_name_or_path.to_token_stream().to_string();
+        let field_name_for_found_value =
+            format_ident!("the_same_or_another_{referencing_table_name}");
 
-        paths_of_traits_to_extend.push(parse_str(&format!("{}::{get_row_of_referenced_table_by_primary_key_trait_name}", &foreign_key.path.to_token_stream().to_string())).expect("should be parseable"));
-
-        let check = quote! {
-            match self.#get_row_of_referenced_table_by_primary_key_method_name(#referencing_table_name.#referencing_table_column_getter_name()) {
-                Some(_) => {},
-                None => {
-                    panic!(
-                        #reference_integrity_violation_error_panic_message,
-                        #referencing_table_name.#referencing_table_column_getter_name(),
-                    );
+        let check = match &create_or_update_dsl_method {
+            CreateOrUpdate::Create => {
+                quote! {
+                    match self.#get_row_of_referenced_table_by_primary_key_method_name(#referencing_table_name.#referencing_table_column_getter_name()) {
+                        Some(_) => {},
+                        None => {
+                            return Err(
+                                spacetimedsl::SpacetimeDSLError::ReferenceIntegrityViolation(
+                                    spacetimedsl::ReferenceIntegrityViolationError::OnCreateOrUpdate {
+                                        table_name: #referencing_table_name_as_string,
+                                        create_or_update: spacetimedsl::Action::Create,
+                                        column_names_and_row_values: format!(#column_names_and_row_values, #referencing_table_name.#referencing_table_column_getter_name())
+                                    }
+                                )
+                            );
+                        }
+                    };
                 }
-            };
+            }
+            CreateOrUpdate::Update => {
+                let row_value_getters =
+                    row_value_getters.expect("Update Method should have row value getters");
+                quote! {
+                    if #field_name_for_found_value.is_none() {
+                        #field_name_for_found_value = match self.ctx().db().#referencing_table_name().id().find(#referencing_table_name.get_id().value()) {
+                            Some(#referencing_table_name) => Some(#referencing_table_name),
+                            None => {
+                                return Err(
+                                    spacetimedsl::SpacetimeDSLError::NotFoundError {
+                                        table_name: #referencing_table_name_as_string,
+                                        column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*)
+                                    }
+                                );
+                            }
+                        };
+                    }
+                    if #field_name_for_found_value.as_ref().unwrap().#referencing_table_column_getter_name().ne(&#referencing_table_name.#referencing_table_column_getter_name()) {
+                        match self.#get_row_of_referenced_table_by_primary_key_method_name(#referencing_table_name.#referencing_table_column_getter_name()) {
+                            Some(_) => {},
+                            None => return Err(
+                                spacetimedsl::SpacetimeDSLError::ReferenceIntegrityViolation(
+                                    spacetimedsl::ReferenceIntegrityViolationError::OnCreateOrUpdate {
+                                        table_name: #referencing_table_name_as_string,
+                                        create_or_update: spacetimedsl::Action::Update,
+                                        column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*)
+                                    }
+                                )
+                            )
+                        };
+                    }
+                }
+            }
         };
 
-        reference_integrity_checks.push(
-            match referencing_table_column_type.trim() {
-            "u8" | "u16" | "u32" | "u64" | "u128"  => quote! {
+        reference_integrity_checks.push(match referencing_table_column_type.trim() {
+            "u8" | "u16" | "u32" | "u64" | "u128" => quote! {
                 if #referencing_table_column_name.ne(&0) {
                     #check
                 }
             },
-            "Option"  => quote! {
+            "Option" => quote! {
                 if #referencing_table_column_name.is_some() {
                     #check
                 }
@@ -1330,52 +1710,16 @@ fn reference_integrity_checks(
     (paths_of_traits_to_extend, reference_integrity_checks)
 }
 
-pub(in crate::internal::dsl::method) struct MultiColumnIndexCheck {
-    index_name: Ident,
-    check: TokenStream,
-}
-
 fn multi_column_index_checks(
+    action: Action,
     struct_name: &Ident,
     singular_table_name: &Ident,
     spacetimedb_table: &SpacetimeDBTable,
     primary_key_column_name: &Ident,
+    column_names_and_row_values: &String,
 ) -> Vec<TokenStream> {
-    let mut multi_column_index_checks =
-        get_unique_multi_column_index_checks(struct_name, singular_table_name, spacetimedb_table);
-
-    for multi_column_index_check in &mut multi_column_index_checks {
-        let field_name_for_found_value = format_ident!("the_same_or_another_{singular_table_name}");
-
-        multi_column_index_check.check.append_all(quote! {
-            match &#field_name_for_found_value {
-                Some(#field_name_for_found_value) => {
-                    if #field_name_for_found_value.#primary_key_column_name.ne(&#singular_table_name.#primary_key_column_name) {
-                        use spacetimedb::table::MaybeError;
-                        return Err(spacetimedb::UniqueConstraintViolation::get()
-                            .map(spacetimedb::TryInsertError::UniqueConstraintViolation)
-                            .expect("Mapping should have worked"));
-                    }
-                },
-                _ => {},
-            };
-        });
-    }
-
-    let multi_column_index_checks: Vec<TokenStream> = multi_column_index_checks
-        .into_iter()
-        .map(|mcic| mcic.check)
-        .collect();
-
-    multi_column_index_checks
-}
-
-pub(in crate::internal::dsl::method) fn get_unique_multi_column_index_checks(
-    struct_name: &Ident,
-    singular_table_name: &Ident,
-    spacetimedb_table: &SpacetimeDBTable,
-) -> Vec<MultiColumnIndexCheck> {
     let mut multi_column_index_checks = vec![];
+    let singular_table_name_as_string = singular_table_name.to_string();
 
     for multi_column_index in &spacetimedb_table.multi_column_indices {
         let index_column_names = match &multi_column_index.index_type {
@@ -1389,53 +1733,94 @@ pub(in crate::internal::dsl::method) fn get_unique_multi_column_index_checks(
             continue;
         }
 
-        let mut column_values = vec![];
+        let index_name = &multi_column_index.name;
 
+        let mut row_value_getters = vec![];
+
+        // TODO: Is it possible to use the row_value_getters multiple times or do they move the values?
         for column_name in index_column_names {
             let column_name = format_ident!("{column_name}");
-            column_values.push(quote! {#singular_table_name.#column_name});
+            row_value_getters.push(quote! {#singular_table_name.#column_name});
         }
 
-        multi_column_index_checks.push(get_unique_multi_column_index_check(
-            struct_name,
+        let mut multi_column_index_check = get_unique_multi_column_index_check(
+            &action,
             &singular_table_name,
-            &multi_column_index.name,
-            &column_values,
-        ));
+            &index_name,
+            &column_names_and_row_values,
+            &row_value_getters,
+        );
+
+        let field_name_for_found_value = format_ident!("the_same_or_another_{singular_table_name}");
+
+        let action_as_ident = format_ident!("{action}");
+
+        let return_unique_constraint_violation_error = quote! {
+            return Err(
+                spacetimedsl::SpacetimeDSLError::UniqueConstraintViolation {
+                    table_name: #singular_table_name_as_string.into(),
+                    action: spacetimedsl::Action::#action_as_ident,
+                    error_from: spacetimedsl::ErrorFrom::SpacetimeDSL,
+                    one_or_multiple: spacetimedsl::OneOrMultiple::Multiple,
+                    column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*)
+                }
+            );
+        };
+
+        let on_some = match action {
+            Action::Create | Action::Get | Action::Delete => {
+                return_unique_constraint_violation_error
+            }
+            Action::Update => {
+                quote! {
+                    if #field_name_for_found_value.#primary_key_column_name.ne(&#singular_table_name.#primary_key_column_name) {
+                        #return_unique_constraint_violation_error
+                    }
+                }
+            }
+        };
+
+        multi_column_index_check.append_all(quote! {
+            match &#field_name_for_found_value {
+                Some(#field_name_for_found_value) => {
+                    #on_some
+                },
+                _ => {},
+            };
+        });
+
+        multi_column_index_checks.push(multi_column_index_check);
     }
 
     multi_column_index_checks
 }
 
 pub(in crate::internal::dsl::method) fn get_unique_multi_column_index_check(
-    struct_name: &Ident,
+    action: &Action,
     singular_table_name: &Ident,
     index_name: &Ident,
-    column_value_getters: &Vec<TokenStream>,
-) -> MultiColumnIndexCheck {
+    column_names_and_row_values: &String,
+    row_value_getters: &Vec<TokenStream>,
+) -> TokenStream {
     let field_name_for_found_value = format_ident!("the_same_or_another_{singular_table_name}");
 
-    let reasons = "There can be two reasons for this: You are inserting or updating somewhere using spacetimedb::ReducerContext instead of spacetimedsl::DSL or the unique multi-column index SpacetimeDSL feature is broken.";
+    let singular_table_name_as_string = singular_table_name.to_string();
 
-    let mut more_than_one_panic_msg = format!(
-        "There must be only one {struct_name} row inside the {singular_table_name} table when filtering on the unique multi-column index {index_name} with value "
-    );
-    more_than_one_panic_msg.push_str("{:?}. Found more than one. ");
-    more_than_one_panic_msg.push_str(reasons);
+    let action = format_ident!("{action}");
 
-    MultiColumnIndexCheck {
-        index_name: index_name.clone(),
-        check: quote! {
-                let #field_name_for_found_value = match self.ctx().db().#singular_table_name().#index_name().filter((#(#column_value_getters),*)).at_most_one() {
-                    Ok(#singular_table_name) => #singular_table_name,
-                    Err(_) => {
-                        panic!(
-                            #more_than_one_panic_msg,
-                            (#(#column_value_getters),*),
-                        );
-                    }
-                };
-        },
+    quote! {
+        #field_name_for_found_value = match self.ctx().db().#singular_table_name().#index_name().filter((#(#row_value_getters),*)).at_most_one() {
+            Ok(#singular_table_name) => #singular_table_name,
+            Err(_) => return Err(
+                spacetimedsl::SpacetimeDSLError::UniqueConstraintViolation {
+                    table_name: #singular_table_name_as_string.into(),
+                    action: spacetimedsl::Action::#action,
+                    error_from: spacetimedsl::ErrorFrom::SpacetimeDSL,
+                    one_or_multiple: spacetimedsl::OneOrMultiple::Multiple,
+                    column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*)
+                }
+            ),
+        };
     }
 }
 
@@ -1468,43 +1853,61 @@ fn for_referenced_by(
         &dsl_internal_referenced_by_function,
         &singular_table_name,
     );
-    let primary_key_value_arg_name;
+
     let paths_of_traits_to_extend = vec![];
     let mut function_args = vec![
         SpacetimeDSLMethodArg {
             is_mut: false,
             arg_name: format_ident!("ctx"),
-            arg_type: quote! { &spacetimedb::ReducerContext }
+            arg_type: quote! { &spacetimedb::ReducerContext },
         },
         SpacetimeDSLMethodArg {
             is_mut: false,
             arg_name: format_ident!("strategy"),
-            arg_type: quote! { spacetimedsl::OnDeleteStrategy }
+            arg_type: quote! { spacetimedsl::OnDeleteStrategy },
         },
     ];
-    // TODO: Result Type
-    let return_type = quote! { Result<(), ()> };
+
+    let return_type;
+
+    let entry_or_entries;
 
     match dsl_internal_referenced_by_function {
         DSLInternalReferencedByFunction::ExecuteOnDeleteStrategiesOfReferencingTablesAfterOneRowOfThisTableWasDeleted => {
-            doc_comment = format!("Execute OnDeleteStrategies of referencing tables after one row of the `{singular_table_name}` table was deleted.");
-            primary_key_value_arg_name = format_ident!("primary_key_value_of_row_to_delete");
+            doc_comment = format!("Execute On Delete Strategies of all referencing tables after one row of the referenced table `{singular_table_name}` was deleted.");
+            entry_or_entries = format_ident!("entry");
             function_args.push(
                 SpacetimeDSLMethodArg {
-                    is_mut: false,
-                    arg_name: primary_key_value_arg_name.clone(),
-                    arg_type: quote! { &#primary_key_column_type } }
+                    is_mut: true,
+                    arg_name: entry_or_entries.clone(),
+                    arg_type: quote! { (&#primary_key_column_type, spacetimedsl::DeletionResultEntry>) }
+                },
             );
+            return_type = quote! {
+                Result<
+                    (&#primary_key_column_type, spacetimedsl::DeletionResultEntry>),
+                    (&#primary_key_column_type, spacetimedsl::DeletionResultEntry>)
+                >
+            };
         }
         DSLInternalReferencedByFunction::ExecuteOnDeleteStrategiesOfReferencingTablesAfterMultipleRowsOfThisTableWereDeleted => {
-            doc_comment = format!("Execute OnDeleteStrategies of referencing tables after multiple rows of the `{singular_table_name}` table were deleted.");
-            primary_key_value_arg_name = format_ident!("primary_key_values_of_rows_to_delete");
+            doc_comment = format!("Execute On Delete Strategies of all referencing tables after multiple rows of the referenced table `{singular_table_name}` were deleted.");
+            entry_or_entries = format_ident!("entries");
             function_args.push(
                 SpacetimeDSLMethodArg {
-                    is_mut: false,
-                    arg_name: primary_key_value_arg_name.clone(),
-                    arg_type: quote! { &Vec<#primary_key_column_type> } }
+                    is_mut: true,
+                    arg_name: entry_or_entries.clone(),
+                    arg_type: quote! {
+                        std::collections::HashMap<&#primary_key_column_type, spacetimedsl::DeletionResultEntry>
+                    }
+                },
             );
+            return_type = quote! {
+                Result<
+                    std::collections::HashMap<&#primary_key_column_type, spacetimedsl::DeletionResultEntry>,
+                    std::collections::HashMap<&#primary_key_column_type, spacetimedsl::DeletionResultEntry>
+                >
+            };
         }
     };
 
@@ -1515,15 +1918,15 @@ fn for_referenced_by(
     let mut strategy_calls = vec![];
 
     for referencing_table in &spacetimedsl_table.referencing_tables {
-        let referencing_table_path = &referencing_table.path;
+        let dsl_internal_foreign_key_function = get_foreign_key_function_by_referenced_by_function(
+            &dsl_internal_referenced_by_function,
+        );
+
         let referencing_table_name = &referencing_table.table_name;
+
         let referencing_table_name_pascal_case = format_ident!(
             "{}",
             RenameRule::PascalCase.apply_to_field(referencing_table_name.to_string())
-        );
-
-        let dsl_internal_foreign_key_function = get_foreign_key_function_by_referenced_by_function(
-            &dsl_internal_referenced_by_function,
         );
 
         let referencing_table_trait_name = get_referencing_table_trait_name(
@@ -1538,16 +1941,23 @@ fn for_referenced_by(
             &singular_table_name,
         );
 
+        let referencing_table_path = &referencing_table.path;
+
         strategy_calls.push(quote! {
             use #referencing_table_path::#referencing_table_trait_name;
-            spacetimedsl::internal::DSLInternals::#referencing_table_function_name(ctx, &strategy, #primary_key_value_arg_name)?;
+            match spacetimedsl::internal::DSLInternals::#referencing_table_function_name(ctx, &strategy, #entry_or_entries) {
+                Err(e) => {
+                    return Err(#entry_or_entries);
+                },
+                Ok(e) => #entry_or_entries = e,
+            };
         });
     }
 
     function_impl = quote! {
         #(#strategy_calls)*
 
-        Ok(())
+        Ok(#entry_or_entries)
     };
 
     SpacetimeDSLMethod {
@@ -1571,17 +1981,12 @@ fn for_foreign_key(
     columns_with_foreign_key: &Vec<&&Column>,
     primary_key_column_name: &Ident,
 ) -> SpacetimeDSLMethod {
-    let primary_key_column_type = 
-        &columns
+    let primary_key_column_type = &columns
         .iter()
-        .find(|c| {
-            c.rust_field
-                .name
-                .eq(primary_key_column_name)
-        })
+        .find(|c| c.rust_field.name.eq(primary_key_column_name))
         .expect("should have a primary key")
-            .rust_field
-            .type_name_or_path;
+        .rust_field
+        .type_name_or_path;
 
     let first_foreign_key_column = columns_with_foreign_key
         .first()
@@ -1596,8 +2001,12 @@ fn for_foreign_key(
     for column_with_foreign_key in columns_with_foreign_key {
         if column_with_foreign_key
             .rust_field
-            .type_name_or_path.to_token_stream().to_string()
-            .ne(&referenced_table_primary_key_column_type.to_token_stream().to_string())
+            .type_name_or_path
+            .to_token_stream()
+            .to_string()
+            .ne(&referenced_table_primary_key_column_type
+                .to_token_stream()
+                .to_string())
         {
             // TODO: If Option is supported, the type of the primary key values needs to be without option and it's allowed to have both, option and non-option columns. There is already a function to remove option from the type representation, search for `Option <`` in the code.
             panic!(
@@ -1615,12 +2024,12 @@ fn for_foreign_key(
             ))
             .on_delete_strategy;
 
-        if !columns_by_on_delete_strategies.contains_key(&on_delete_strategy) {
+        if !columns_by_on_delete_strategies.contains_key(on_delete_strategy) {
             columns_by_on_delete_strategies.insert(on_delete_strategy, vec![]);
         }
 
         columns_by_on_delete_strategies
-            .get_mut(&on_delete_strategy)
+            .get_mut(on_delete_strategy)
             .expect("The key OnDeleteStrategy should exist!")
             .push(column_with_foreign_key);
     }
@@ -1652,77 +2061,105 @@ fn for_foreign_key(
         &referenced_table_name,
     );
 
-    let primary_key_value_arg_name;
-
     let paths_of_traits_to_extend = vec![];
     let mut function_args = vec![
         SpacetimeDSLMethodArg {
             is_mut: false,
             arg_name: format_ident!("ctx"),
-            arg_type: quote! { &spacetimedb::ReducerContext }
+            arg_type: quote! { &spacetimedb::ReducerContext },
         },
         SpacetimeDSLMethodArg {
             is_mut: false,
             arg_name: format_ident!("strategy"),
-            arg_type: quote! { &spacetimedsl::OnDeleteStrategy }
+            arg_type: quote! { &spacetimedsl::OnDeleteStrategy },
         },
     ];
 
-    // TODO: Result Type
-    let return_type = quote! {
-        Result<(),()>
-    };
+    let return_type;
+
+    let one_or_multiple;
+    let entry_or_entries;
 
     match dsl_internal_foreign_key_function {
         DSLInternalForeignKeyFunction::ExecuteOnDeleteStrategiesOfThisTableAfterOneRowOfTheReferencedTableWasDeleted => {
-            doc_comment = format!("Execute OnDeleteStrategies of the `{singular_table_name}` table after one row of the `{referenced_table_name}` table was deleted.");
-            primary_key_value_arg_name = format_ident!("primary_key_value_of_row_to_delete");
+            doc_comment = format!("Execute On Delete Strategies of the referencing table `{singular_table_name}` after one row of the referenced table `{referenced_table_name}` was deleted.");
+            one_or_multiple = OneOrMultiple::One;
+            entry_or_entries = format_ident!("entry");
             function_args.push(
                 SpacetimeDSLMethodArg {
-                    is_mut: false,
-                    arg_name: primary_key_value_arg_name.clone(),
-                    arg_type: quote! { &#referenced_table_primary_key_column_type }
-                }
+                    is_mut: true,
+                    arg_name: entry_or_entries.clone(),
+                    arg_type: quote! { (&#primary_key_column_type, spacetimedsl::DeletionResultEntry>) }
+                },
             );
+            return_type = quote! {
+                Result<
+                    (&#primary_key_column_type, spacetimedsl::DeletionResultEntry>),
+                    (&#primary_key_column_type, spacetimedsl::DeletionResultEntry>)
+                >
+            };
         }
         DSLInternalForeignKeyFunction::ExecuteOnDeleteStrategiesOfThisTableAfterMultipleRowsOfTheReferencedTableWereDeleted => {
-            doc_comment = format!("Execute OnDeleteStrategies of the `{singular_table_name}` table after multiple rows of the `{referenced_table_name}` table were deleted.");
-            primary_key_value_arg_name = format_ident!("primary_key_values_of_rows_to_delete");
+            doc_comment = format!("Execute On Delete Strategies of the referencing table `{singular_table_name}` after multiple rows of the referenced table `{referenced_table_name}` were deleted.");
+            one_or_multiple = OneOrMultiple::Multiple;
+            entry_or_entries = format_ident!("entries");
             function_args.push(
                 SpacetimeDSLMethodArg {
-                    is_mut: false,
-                    arg_name: primary_key_value_arg_name.clone(),
-                    arg_type: quote! { &Vec<#referenced_table_primary_key_column_type> }
-                }
+                    is_mut: true,
+                    arg_name: entry_or_entries.clone(),
+                    arg_type: quote! {
+                        std::collections::HashMap<&#primary_key_column_type, spacetimedsl::DeletionResultEntry>
+                    }
+                },
             );
+            return_type = quote! {
+                Result<
+                    std::collections::HashMap<&#primary_key_column_type, spacetimedsl::DeletionResultEntry>,
+                    std::collections::HashMap<&#primary_key_column_type, spacetimedsl::DeletionResultEntry>
+                >
+            };
         }
     };
 
     let doc_comment = doc_comment.into();
     let function_impl;
 
-    let mut on_delete_strategy_match_arms = vec![];
+    let mut on_delete_strategy_match_arms = HashMap::new();
+
+    for on_delete_strategy in OnDeleteStrategy::iter() {
+        on_delete_strategy_match_arms.insert(
+            on_delete_strategy.clone(),
+            quote! {
+                #on_delete_strategy => { }
+            },
+        );
+    }
 
     for (on_delete_strategy, columns_by_on_delete_strategy) in columns_by_on_delete_strategies {
-        on_delete_strategy_match_arms.push(get_on_delete_strategy_implementation(
-            &struct_name,
-            &singular_table_name,
-            &primary_key_column_name,
-            primary_key_column_type,
-            &spacetimedsl_table,
-            &dsl_internal_foreign_key_function,
-            on_delete_strategy,
-            columns_by_on_delete_strategy,
-        ));
+        on_delete_strategy_match_arms.insert(
+            on_delete_strategy.clone(),
+            get_on_delete_strategy_implementation(
+                struct_name,
+                singular_table_name,
+                &primary_key_column_name,
+                primary_key_column_type,
+                spacetimedsl_table,
+                on_delete_strategy,
+                columns_by_on_delete_strategy,
+                &one_or_multiple,
+                &entry_or_entries,
+            ),
+        );
     }
+
+    let on_delete_strategy_match_arms = on_delete_strategy_match_arms.values().collect_vec();
 
     function_impl = quote! {
         match &strategy {
-            #(#on_delete_strategy_match_arms)*
-            _ => {}
+            #(#on_delete_strategy_match_arms),*
         };
 
-        Ok(())
+        Ok(#entry_or_entries)
     };
 
     SpacetimeDSLMethod {
@@ -1736,22 +2173,32 @@ fn for_foreign_key(
     }
 }
 
+#[derive(Debug)]
+pub enum OneOrMultiple {
+    One,
+    Multiple,
+}
+
 fn get_on_delete_strategy_implementation(
     struct_name: &Ident,
     singular_table_name: &Ident,
     primary_key_column_name: &Ident,
     primary_key_column_type: &Path,
     spacetimedsl_table: &SpacetimeDSLTable,
-    dsl_internal_foreign_key_function: &DSLInternalForeignKeyFunction,
     on_delete_strategy: &OnDeleteStrategy,
     columns_by_on_delete_strategy: Vec<&&&Column>,
+    one_or_multiple: &OneOrMultiple,
+    entry_or_entries: &Ident,
 ) -> TokenStream {
     let mut strategy_before_all_columns = TokenStream::default();
-    let mut strategy_by_column = vec![];
+    let mut strategies = vec![];
     let mut strategy_after_all_columns = TokenStream::default();
+
+    let singular_table_name_as_string = singular_table_name.to_string();
 
     for column in &columns_by_on_delete_strategy {
         let column_name = &column.rust_field.name;
+        let column_name_as_string = column_name.to_string();
 
         let is_unique_index = column
             .spacetimedb_column
@@ -1769,188 +2216,261 @@ fn get_on_delete_strategy_implementation(
         let row_finder = match is_unique_index {
             true => {
                 quote! {
-                    #spacetimedb_call_prefix.#column_name().find(primary_key_value_of_row_to_delete)
+                    #spacetimedb_call_prefix.#column_name().find(referenced_row_primary_key_value)
                 }
             }
             false => {
                 quote! {
-                    #spacetimedb_call_prefix.#column_name().filter(primary_key_value_of_row_to_delete)
+                    #spacetimedb_call_prefix.#column_name().filter(referenced_row_primary_key_value)
                 }
             }
         };
 
-        strategy_by_column.push(match on_delete_strategy {
-            OnDeleteStrategy::Error => {
-                let strategy_per_row = quote! {
-                    return Err(());
-                };
+        let referenced_table_one_function_name = get_referenced_table_function_name(
+            &DSLInternalReferencedByFunction::ExecuteOnDeleteStrategiesOfReferencingTablesAfterOneRowOfThisTableWasDeleted,
+            &singular_table_name
+        );
 
-                match is_unique_index {
-                    true => {
-                        quote! {
-                            if #row_finder.is_some() {
-                                #strategy_per_row
-                            };
-                        }
-                    }
-                    false => {
-                        quote! {
-                            if #row_finder.next().is_some() {
-                                #strategy_per_row
-                            }
-                        }
-                    }
+        let referenced_table_multiple_function_name = get_referenced_table_function_name(
+            &DSLInternalReferencedByFunction::ExecuteOnDeleteStrategiesOfReferencingTablesAfterMultipleRowsOfThisTableWereDeleted,
+            &singular_table_name
+        );
+
+        let one_or_multiple_as_ident = match one_or_multiple {
+            OneOrMultiple::One => format_ident!("One"),
+            OneOrMultiple::Multiple => format_ident!("Multiple"),
+        };
+
+        let get_child_entries = match on_delete_strategy {
+            OnDeleteStrategy::Error | OnDeleteStrategy::SetZero | OnDeleteStrategy::Ignore => {
+                quote! {
+                    let child_entries = vec![];
                 }
             }
-            OnDeleteStrategy::Delete => {
-                let optional_primary_key_value_setter;
+            OnDeleteStrategy::Delete => quote! {
+                // FIXME: I need better recursive functions for the result creation...
 
-                if spacetimedsl_table.referencing_tables.is_empty() {
-                    optional_primary_key_value_setter = TokenStream::default();
+                let mut child_entries = vec![];
 
-                    strategy_before_all_columns = quote! {
-                        let mut rows_to_delete: Vec<#struct_name> = vec![];
-                    };
+                 match spacetimedsl::internal::DSLInternals::#referenced_table_one_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::Error, #entry_or_entries) {
+                    Err(e) => {
+                        return Err(spacetimedsl::DeletionResult {
+                            table_name: #singular_table_name_as_string.into(),
+                            one_or_multiple: spacetimedsl::OneOrMultiple::#one_or_multiple_as_ident,
+                            entries: e.into_values().collect_vec(),
+                        });
+                    },
+                    Ok(e) => entries = e,
+                };
 
-                    strategy_after_all_columns = quote! {
-                        for row_to_delete in rows_to_delete {
-                            #spacetimedb_call_prefix
-                                .#primary_key_column_name()
-                                .delete(row_to_delete.#primary_key_column_name);
-                        }
-                    };
-                } else {
-                    match is_unique_index {
-                        true => {
-                            optional_primary_key_value_setter = quote! {
-                                pk_values_of_rows_to_delete.push(row.#primary_key_column_name);
-                            };
-                        }
-                        false => {
-                            optional_primary_key_value_setter = quote! {
-                                let mut primary_keys = rows.iter().map(|row| row.#primary_key_column_name).collect();
-                                pk_values_of_rows_to_delete.append(&mut primary_keys);
-                            }
-                        }
-                    };
+                match spacetimedsl::internal::DSLInternals::#referenced_table_one_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::Delete, #entry_or_entries) {
+                    Err(e) => {
+                        return Err(spacetimedsl::DeletionResult {
+                            table_name: #singular_table_name_as_string.into(),
+                            one_or_multiple: spacetimedsl::OneOrMultiple::#one_or_multiple_as_ident,
+                            entries: e.into_values().collect_vec(),
+                        });
+                    },
+                    Ok(e) => entries = e,
+                };
 
-                    strategy_before_all_columns = quote! {
-                        let mut pk_values_of_rows_to_delete: Vec<#primary_key_column_type> = vec![];
-                        let mut rows_to_delete: Vec<#struct_name> = vec![];
-                    };
+                /* // FIXME: If SetNone is implemented
+                match spacetimedsl::internal::DSLInternals::#referenced_table_one_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::SetNone, #entry_or_entries) {
+                    Err(e) => {
+                        return Err(spacetimedsl::DeletionResult {
+                            table_name: #singular_table_name_as_string.into(),
+                            one_or_multiple: spacetimedsl::OneOrMultiple::#one_or_multiple_as_ident,
+                            entries: e.into_values().collect_vec(),
+                        });
+                    },
+                    Ok(e) => entries = e,
+                };
+                */
 
-                    let delete_one_hooks = get_referenced_table_function_name(
-                        &DSLInternalReferencedByFunction::ExecuteOnDeleteStrategiesOfReferencingTablesAfterOneRowOfThisTableWasDeleted,
-                        &singular_table_name
+                match spacetimedsl::internal::DSLInternals::#referenced_table_one_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::SetZero, #entry_or_entries) {
+                    Err(e) => {
+                        return Err(spacetimedsl::DeletionResult {
+                            table_name: #singular_table_name_as_string.into(),
+                            one_or_multiple: spacetimedsl::OneOrMultiple::#one_or_multiple_as_ident,
+                            entries: e.into_values().collect_vec(),
+                        });
+                    },
+                    Ok(e) => entries = e,
+                };
+            },
+        };
+
+        let create_child_entry = quote! {
+            spacetimedsl::DeletionResultEntry {
+                table_name: #singular_table_name_as_string.into(),
+                column_name: #column_name_as_string.into(),
+                strategy: spacetimedsl::OnDeleteStrategy::#on_delete_strategy,
+                row_value: format!("{}", row.id).into(),
+                child_entries,
+            }
+        };
+
+        let add_row_as_child_entry_to_referenced_row;
+
+        match one_or_multiple {
+            OneOrMultiple::One => {
+                add_row_as_child_entry_to_referenced_row = quote! {
+                    #get_child_entries
+
+                    #entry_or_entries.1.child_entries.push(
+                        #create_child_entry
                     );
+                };
+            }
+            OneOrMultiple::Multiple => {
+                add_row_as_child_entry_to_referenced_row = quote! {
+                    #get_child_entries
 
-                    let delete_many_hooks = get_referenced_table_function_name(
-                        &DSLInternalReferencedByFunction::ExecuteOnDeleteStrategiesOfReferencingTablesAfterMultipleRowsOfThisTableWereDeleted,
-                        &singular_table_name
+                    #entry_or_entries.get_mut(&referenced_row_primary_key_value).unwrap().child_entries.push(
+                        #create_child_entry
                     );
+                };
+            }
+        };
 
-                    strategy_after_all_columns = quote! {
-                        if pk_values_of_rows_to_delete.len().eq(&1) {
-                            let primary_key_value_of_row_to_delete = pk_values_of_rows_to_delete[0];
+        let strategy;
 
-                            spacetimedsl::internal::DSLInternals::#delete_one_hooks(ctx, spacetimedsl::OnDeleteStrategy::Error, &primary_key_value_of_row_to_delete)?;
-                            spacetimedsl::internal::DSLInternals::#delete_one_hooks(ctx, spacetimedsl::OnDeleteStrategy::Delete, &primary_key_value_of_row_to_delete)?;
-                            //TODO: spacetimedsl::internal::DSLInternals::#delete_one_hooks(ctx, spacetimedsl::OnDeleteStrategy::SetNone, &primary_key_value_of_row_to_delete)?;
-                            spacetimedsl::internal::DSLInternals::#delete_one_hooks(ctx, spacetimedsl::OnDeleteStrategy::SetZero, &primary_key_value_of_row_to_delete)?;
+        match on_delete_strategy {
+            OnDeleteStrategy::Error => {
+                strategy_before_all_columns = quote! {
+                    let mut is_err = false;
+                };
 
-                            let row_to_delete = &rows_to_delete[0];
+                let strategy_per_row = quote! {
+                    is_err = true;
 
-                            #spacetimedb_call_prefix
-                                .#primary_key_column_name()
-                                .delete(row_to_delete.#primary_key_column_name);
-                        } else {
-                            spacetimedsl::internal::DSLInternals::#delete_many_hooks(ctx, spacetimedsl::OnDeleteStrategy::Error, &pk_values_of_rows_to_delete)?;
-                            spacetimedsl::internal::DSLInternals::#delete_many_hooks(ctx, spacetimedsl::OnDeleteStrategy::Delete, &pk_values_of_rows_to_delete)?;
-                            //TODO: spacetimedsl::internal::DSLInternals::#delete_many_hooks(ctx, spacetimedsl::OnDeleteStrategy::SetNone, &pk_values_of_rows_to_delete)?;
-                            spacetimedsl::internal::DSLInternals::#delete_many_hooks(ctx, spacetimedsl::OnDeleteStrategy::SetZero, &pk_values_of_rows_to_delete)?;
-                            for row_to_delete in rows_to_delete {
-                                #spacetimedb_call_prefix
-                                    .#primary_key_column_name()
-                                    .delete(row_to_delete.#primary_key_column_name);
-                            }
+                    #add_row_as_child_entry_to_referenced_row
+                };
+
+                strategy_after_all_columns = quote! {
+                    match is_err {
+                        false => return Ok(#entry_or_entries),
+                        true => return Err(#entry_or_entries),
+                    }
+                };
+
+                strategy = match is_unique_index {
+                    true => quote! {
+                        let row = #row_finder;
+
+                        if row.is_some() {
+                            #strategy_per_row
                         };
-                    };
-                }
+                    },
+                    false => quote! {
+                        let rows = #row_finder;
 
-                match is_unique_index {
-                    true => {
-                        quote! {
-                            match #row_finder {
-                                None => {}
-                                Some(row) => { 
-                                    #optional_primary_key_value_setter
-                                    rows_to_delete.push(row);
-                                }
-                            };
+                        for row in &rows {
+                            #strategy_per_row
                         }
+                    },
+                };
+            }
+            OnDeleteStrategy::Delete => {
+                strategy_before_all_columns = quote! {
+                    let mut primary_key_referencing_rows = std::collections::HashSet::new();
+                };
+
+                strategy_after_all_columns = quote! {
+                    for primary_key_referencing_row in primary_key_referencing_rows {
+                        #add_row_as_child_entry_to_referenced_row
+
+                        // FIXME: On false Error
+                        #spacetimedb_call_prefix
+                            .#primary_key_column_name()
+                            .delete(primary_key_referencing_row.#primary_key_column_name);
                     }
-                    false => {
-                        quote! {
-                            let mut rows: Vec<#struct_name> = #row_finder.collect();
-                            #optional_primary_key_value_setter
-                            rows_to_delete.append(&mut rows);
+                };
+
+                strategy = match is_unique_index {
+                    true => quote! {
+                        match #row_finder {
+                            None => {},
+                            Some(row) => primary_key_referencing_rows.insert(row),
+                        };
+                    },
+                    false => quote! {
+                        for row in #row_finder {
+                            primary_key_referencing_rows.insert(row);
                         }
-                    }
-                }
+                    },
+                };
             }
             OnDeleteStrategy::SetZero => {
                 let strategy_per_row = quote! {
                     row.#column_name = 0;
+
+                    #add_row_as_child_entry_to_referenced_row
+
+                    // FIXME: try_update instead of update
+                    // FIXME: on error return Err(spacetimedsl::SpacetimeDSLError);
                     #spacetimedb_call_prefix.#primary_key_column_name().update(row);
                 };
 
-                match is_unique_index {
-                    true => {
-                        quote! {
-                            match #row_finder {
-                                None => {}
-                                Some(mut row) => { #strategy_per_row }
-                            };
+                strategy = match is_unique_index {
+                    true => quote! {
+                        match #row_finder {
+                            None => {}
+                            Some(mut row) => { #strategy_per_row }
+                        };
+                    },
+                    false => quote! {
+                        for mut row in #row_finder {
+                            #strategy_per_row
                         }
-                    }
-                    false => {
-                        quote! {
-                            #row_finder.for_each(|mut row| {
-                                #strategy_per_row
-                            });
-                        }
-                    }
-                }
+                    },
+                };
             }
-            OnDeleteStrategy::Ignore => quote! {},
-        })
+            OnDeleteStrategy::Ignore => {
+                let strategy_per_row = quote! {
+                    #add_row_as_child_entry_to_referenced_row
+                };
+
+                strategy = match is_unique_index {
+                    true => quote! {
+                        match #row_finder {
+                            None => {}
+                            Some(row) => { #strategy_per_row }
+                        };
+                    },
+                    false => quote! {
+                        for row in #row_finder {
+                            #strategy_per_row
+                        }
+                    },
+                };
+            }
+        };
+
+        strategies.push(strategy);
     }
 
-    match dsl_internal_foreign_key_function {
-        DSLInternalForeignKeyFunction::ExecuteOnDeleteStrategiesOfThisTableAfterOneRowOfTheReferencedTableWasDeleted => {
-            quote! {
-                #on_delete_strategy => {
-                    #strategy_before_all_columns
+    let strategies = match one_or_multiple {
+        OneOrMultiple::One => quote! {
+            let referenced_row_primary_key_value = entry.0;
 
-                    #(#strategy_by_column)*
-
-                    #strategy_after_all_columns
-                }
+            #(#strategies)*
+        },
+        OneOrMultiple::Multiple => quote! {
+            for referenced_row_primary_key_value in entries.keys() {
+                #(#strategies)*
             }
         },
-        DSLInternalForeignKeyFunction::ExecuteOnDeleteStrategiesOfThisTableAfterMultipleRowsOfTheReferencedTableWereDeleted => {
-            quote! {
-                #on_delete_strategy => {
-                    #strategy_before_all_columns
+    };
 
-                    for primary_key_value_of_row_to_delete in primary_key_values_of_rows_to_delete {
-                        #(#strategy_by_column)*
-                    }
+    quote! {
+        #on_delete_strategy => {
+            #strategy_before_all_columns
 
-                    #strategy_after_all_columns
-                }
-            }
-        },
+            #strategies
+
+            #strategy_after_all_columns
+        }
     }
 }
 

--- a/derive-input/src/internal/dsl/method.rs
+++ b/derive-input/src/internal/dsl/method.rs
@@ -641,13 +641,13 @@ pub(in crate::internal) fn for_method(
             let mut column_names_and_row_values = String::new();
             column_names_and_row_values.push_str("{{ ");
             column_names_and_row_values.push_str(&format!("{singular_table_name} : "));
-            column_names_and_row_values.push_str("{} }}");
+            column_names_and_row_values.push_str("{:?} }}");
 
             let multi_column_index_checks = multi_column_index_checks(
                 Action::Create,
                 &singular_table_name,
                 &spacetimedb_table,
-                &column_names_and_row_values,
+                None,
             );
 
             let use_itertools = if multi_column_index_checks.len() > 0 {
@@ -663,7 +663,7 @@ pub(in crate::internal) fn for_method(
                 spacetimedb_table,
                 &internal_columns,
                 paths_of_traits_to_extend,
-                (&column_names_and_row_values, None),
+                None,
             );
             paths_of_traits_to_extend = res.0;
             let reference_integrity_checks = res.1;
@@ -696,7 +696,7 @@ pub(in crate::internal) fn for_method(
                                 action: spacetimedsl::Action::Create,
                                 error_from: spacetimedsl::ErrorFrom::SpacetimeDB,
                                 one_or_multiple: #one,
-                                column_names_and_row_values: format!("{:?}", #singular_table_name).into(),
+                                column_names_and_row_values: format!(#column_names_and_row_values, #singular_table_name).into(),
                             })
                         }
                         spacetimedb::TryInsertError::AutoIncOverflow(_) => {
@@ -929,7 +929,7 @@ pub(in crate::internal) fn for_method(
                         Action::Update,
                         &singular_table_name,
                         &spacetimedb_table,
-                        &column_names_and_row_values,
+                        Some(&column_names_and_row_values),
                     );
 
                     let mut row_value_getters = vec![];
@@ -978,7 +978,7 @@ pub(in crate::internal) fn for_method(
                         spacetimedb_table,
                         internal_columns,
                         paths_of_traits_to_extend,
-                        (&column_names_and_row_values, Some(&row_value_getters)),
+                        Some((&column_names_and_row_values, &row_value_getters)),
                     );
                     paths_of_traits_to_extend = res.0;
                     let reference_integrity_checks = res.1;
@@ -1706,12 +1706,9 @@ fn reference_integrity_checks_on_create_or_update(
     spacetimedb_table: &SpacetimeDBTable,
     columns: &Vec<InternalColumn>,
     mut paths_of_traits_to_extend: Vec<Path>,
-    column_names_and_row_value_getters: (&String, Option<&Vec<TokenStream>>),
+    column_names_and_row_value_getters: Option<(&String, &Vec<TokenStream>)>,
 ) -> (Vec<Path>, Vec<TokenStream>) {
     let mut reference_integrity_checks = vec![];
-
-    let column_names_and_row_values = column_names_and_row_value_getters.0;
-    let row_value_getters = column_names_and_row_value_getters.1;
 
     for column in columns {
         // Checks of private columns only need to happen in checks for create methods, because they can't be changed, they don't need to be checked during updates
@@ -1776,7 +1773,7 @@ fn reference_integrity_checks_on_create_or_update(
                                     spacetimedsl::ReferenceIntegrityViolationError::OnCreateOrUpdate {
                                         table_name: #referencing_table_name_as_string.into(),
                                         create_or_update: spacetimedsl::Action::Create,
-                                        column_names_and_row_values: format!(#column_names_and_row_values, #referencing_table_name.#referencing_table_column_getter_name()).into()
+                                        column_names_and_row_values: format!("{{ {} : {} }}", #referencing_table_column_name, #referencing_table_name.#referencing_table_column_getter_name()).into()
                                     }
                                 )
                             );
@@ -1785,8 +1782,10 @@ fn reference_integrity_checks_on_create_or_update(
                 }
             }
             CreateOrUpdate::Update => {
-                let row_value_getters =
-                    row_value_getters.expect("Update Method should have row value getters");
+                let column_names_and_row_value_getters = column_names_and_row_value_getters
+                    .expect("Update Method should have column_names_and_row_value_getters");
+                let column_names_and_row_values = column_names_and_row_value_getters.0;
+                let row_value_getters = column_names_and_row_value_getters.1;
                 quote! {
                     if #field_name_for_found_value.is_none() {
                         #field_name_for_found_value = match self.ctx().db().#referencing_table_name().id().find(#referencing_table_name.get_id().value()) {
@@ -1843,14 +1842,14 @@ fn multi_column_index_checks(
     action: Action,
     singular_table_name: &Ident,
     spacetimedb_table: &SpacetimeDBTable,
-    column_names_and_row_values: &String,
+    column_names_and_row_values: Option<&String>,
 ) -> Vec<TokenStream> {
     let mut multi_column_index_checks = vec![];
     let singular_table_name_as_string = singular_table_name.to_string();
 
     for multi_column_index in &spacetimedb_table.multi_column_indices {
-        let index_column_names = match &multi_column_index.index_type {
-            IndexType::BTreeMultiColumn { columns } => columns,
+        let mut index_column_names: VecDeque<Ident> = match &multi_column_index.index_type {
+            IndexType::BTreeMultiColumn { columns } => columns.clone().into(),
             _ => {
                 continue;
             }
@@ -1864,11 +1863,43 @@ fn multi_column_index_checks(
 
         let mut row_value_getters = vec![];
 
-        // TODO: Is it possible to use the row_value_getters multiple times or do they move the values?
-        for column_name in index_column_names {
-            let column_name = format_ident!("{column_name}");
-            row_value_getters.push(quote! {#singular_table_name.#column_name});
-        }
+        let column_names_and_row_values = match column_names_and_row_values {
+            Some(column_names_and_row_values) => {
+                for column_name in &index_column_names {
+                    row_value_getters.push(quote! {#singular_table_name.#column_name});
+                }
+                column_names_and_row_values.clone()
+            }
+            None => {
+                let mut column_names_and_row_values = String::new();
+
+                let first_column_name = index_column_names
+                    .pop_front()
+                    .expect("There should be a first column in Vec<Ident> of BTreeMultiColumn.");
+
+                let last_column_name = index_column_names
+                    .pop_back()
+                    .expect("There should be a last column in Vec<Ident> of BTreeMultiColumn.");
+
+                let any_other_column_name = index_column_names;
+
+                column_names_and_row_values.push_str(&format!("{first_column_name} : "));
+                column_names_and_row_values.push_str("{} ");
+                row_value_getters.push(quote! {#singular_table_name.#first_column_name});
+
+                for any_other_column_name in any_other_column_name {
+                    column_names_and_row_values.push_str(&format!(", {any_other_column_name} : "));
+                    column_names_and_row_values.push_str("{} ");
+                    row_value_getters.push(quote! {#singular_table_name.#any_other_column_name});
+                }
+
+                column_names_and_row_values.push_str(&format!(", {last_column_name} : "));
+                column_names_and_row_values.push_str("{}");
+                row_value_getters.push(quote! {#singular_table_name.#last_column_name});
+
+                column_names_and_row_values
+            }
+        };
 
         let mut multi_column_index_check = get_unique_multi_column_index_check(
             &action,

--- a/derive-input/src/internal/dsl/method.rs
+++ b/derive-input/src/internal/dsl/method.rs
@@ -1213,7 +1213,7 @@ pub(in crate::internal) fn for_method(
                             };
 
                             let impl_until_return_ok_on_is_empty = quote! {
-                                use itertools::Itertools;
+                                use spacetimedsl::itertools::Itertools;
 
                                 #(#wrapper_type_option_to_wrapped_type_option_mappers)*
 
@@ -1462,7 +1462,7 @@ pub(in crate::internal) fn for_method(
                                 };
 
                             let impl_until_return_err_on_is_none = quote! {
-                                use itertools::Itertools;
+                                use spacetimedsl::itertools::Itertools;
 
                                 #(#wrapper_type_option_to_wrapped_type_option_mappers)*
 

--- a/derive-input/src/internal/dsl/method.rs
+++ b/derive-input/src/internal/dsl/method.rs
@@ -1926,6 +1926,7 @@ fn get_on_delete_strategy_implementation(
                     }
                 }
             }
+            OnDeleteStrategy::Ignore => quote! {},
         })
     }
 

--- a/derive-input/src/internal/dsl/method.rs
+++ b/derive-input/src/internal/dsl/method.rs
@@ -46,6 +46,33 @@ pub(in crate::internal) enum DSLMethod<'a> {
 
 // FIXME: Ensure that any panic! / expect() / unwrap() is replaced by proper error handling, either returning spacetimedsl::SpacetimeDSLError during runtime or syn::Error during compilation time
 
+#[derive(Debug)]
+pub enum OneOrMultiple {
+    One,
+    Multiple,
+}
+
+impl quote::ToTokens for OneOrMultiple {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        use proc_macro2::{Punct, Spacing};
+        use quote::{TokenStreamExt, format_ident};
+
+        tokens.append(format_ident!("spacetimedsl"));
+        tokens.append(Punct::new(':', Spacing::Joint));
+        tokens.append(Punct::new(':', Spacing::Alone));
+        tokens.append(format_ident!("OneOrMultiple"));
+        tokens.append(Punct::new(':', Spacing::Joint));
+        tokens.append(Punct::new(':', Spacing::Alone));
+        tokens.append(format_ident!(
+            "{}",
+            match self {
+                OneOrMultiple::One => "One",
+                OneOrMultiple::Multiple => "Multiple",
+            },
+        ));
+    }
+}
+
 #[derive(PartialEq)]
 enum CreateOrUpdate {
     Create,
@@ -96,7 +123,6 @@ impl SpacetimeDSLColumnMethods {
         spacetimedb_table: &SpacetimeDBTable,
         spacetimedsl_table: &SpacetimeDSLTable,
         spacetimedb_column: &SpacetimeDBColumn,
-        primary_key_column_name: &Ident,
         internal_columns: &Vec<InternalColumn>,
     ) -> Option<SpacetimeDSLColumnMethods> {
         let index = match &spacetimedb_column.single_column_index {
@@ -113,7 +139,6 @@ impl SpacetimeDSLColumnMethods {
                     rust_struct,
                     spacetimedb_table,
                     spacetimedsl_table,
-                    primary_key_column_name,
                     internal_columns,
                 );
 
@@ -122,7 +147,6 @@ impl SpacetimeDSLColumnMethods {
                     rust_struct,
                     spacetimedb_table,
                     spacetimedsl_table,
-                    primary_key_column_name,
                     internal_columns,
                 );
 
@@ -137,7 +161,6 @@ impl SpacetimeDSLColumnMethods {
                     rust_struct,
                     spacetimedb_table,
                     spacetimedsl_table,
-                    primary_key_column_name,
                     internal_columns,
                 );
 
@@ -148,7 +171,6 @@ impl SpacetimeDSLColumnMethods {
                         rust_struct,
                         spacetimedb_table,
                         spacetimedsl_table,
-                        primary_key_column_name,
                         internal_columns,
                     )),
                 };
@@ -158,7 +180,6 @@ impl SpacetimeDSLColumnMethods {
                     rust_struct,
                     spacetimedb_table,
                     spacetimedsl_table,
-                    primary_key_column_name,
                     internal_columns,
                 );
 
@@ -180,7 +201,6 @@ impl SpacetimeDSLTableMethods {
         spacetimedb_table: &SpacetimeDBTable,
         spacetimedsl_table: &SpacetimeDSLTable,
         columns: &Vec<Column>,
-        primary_key_column_name: &Ident,
         internal_columns: &Vec<InternalColumn>,
     ) -> syn::Result<SpacetimeDSLTableMethods> {
         let create = for_method(
@@ -188,7 +208,6 @@ impl SpacetimeDSLTableMethods {
             rust_struct,
             spacetimedb_table,
             spacetimedsl_table,
-            primary_key_column_name,
             internal_columns,
         );
 
@@ -197,7 +216,6 @@ impl SpacetimeDSLTableMethods {
             rust_struct,
             spacetimedb_table,
             spacetimedsl_table,
-            primary_key_column_name,
             internal_columns,
         );
 
@@ -206,7 +224,6 @@ impl SpacetimeDSLTableMethods {
             rust_struct,
             spacetimedb_table,
             spacetimedsl_table,
-            primary_key_column_name,
             internal_columns,
         );
 
@@ -219,15 +236,14 @@ impl SpacetimeDSLTableMethods {
             execute_on_delete_strategies_of_referencing_tables_after_multiple_rows_of_this_table_were_deleted = None;
         } else {
             execute_on_delete_strategies_of_referencing_tables_after_one_row_of_this_table_was_deleted = Some(for_referenced_by(
-                DSLInternalReferencedByFunction::ExecuteOnDeleteStrategiesOfReferencingTablesAfterOneRowOfThisTableWasDeleted,
+                &OneOrMultiple::One,
                 spacetimedb_table,
                 spacetimedsl_table,
                 columns,
-                primary_key_column_name,
             ));
 
             execute_on_delete_strategies_of_referencing_tables_after_multiple_rows_of_this_table_were_deleted = Some(for_referenced_by(
-                DSLInternalReferencedByFunction::ExecuteOnDeleteStrategiesOfReferencingTablesAfterMultipleRowsOfThisTableWereDeleted,
+                &OneOrMultiple::Multiple,
                 spacetimedb_table,
                 spacetimedsl_table,
                 columns,
@@ -273,26 +289,24 @@ impl SpacetimeDSLTableMethods {
                 .for_each(|(referenced_table_name, columns_with_foreign_key)| {
                     execute_on_delete_strategies_of_this_table_after_one_row_of_the_referenced_table_was_deleted.push(
                         for_foreign_key(
-                            DSLInternalForeignKeyFunction::ExecuteOnDeleteStrategiesOfThisTableAfterOneRowOfTheReferencedTableWasDeleted,
                             rust_struct,
+                            &OneOrMultiple::One,
                             spacetimedb_table,
                             spacetimedsl_table,
                             columns,
                             referenced_table_name,
                             &columns_with_foreign_key,
-                            primary_key_column_name,
                         )
                     );
                     execute_on_delete_strategies_of_this_table_after_multiple_rows_of_the_referenced_table_were_deleted.push(
                         for_foreign_key(
-                            DSLInternalForeignKeyFunction::ExecuteOnDeleteStrategiesOfThisTableAfterMultipleRowsOfTheReferencedTableWereDeleted,
                             rust_struct,
+                            &OneOrMultiple::Multiple,
                             spacetimedb_table,
                             spacetimedsl_table,
                             columns,
                             referenced_table_name,
                             &columns_with_foreign_key,
-                            primary_key_column_name,
                         )
                     );
                 });
@@ -308,7 +322,6 @@ impl SpacetimeDSLTableMethods {
                         rust_struct,
                         spacetimedb_table,
                         spacetimedsl_table,
-                        primary_key_column_name,
                         internal_columns,
                     );
                     let delete_many = for_method(
@@ -316,7 +329,6 @@ impl SpacetimeDSLTableMethods {
                         rust_struct,
                         spacetimedb_table,
                         spacetimedsl_table,
-                        primary_key_column_name,
                         internal_columns,
                     );
 
@@ -333,7 +345,6 @@ impl SpacetimeDSLTableMethods {
                         rust_struct,
                         spacetimedb_table,
                         spacetimedsl_table,
-                        primary_key_column_name,
                         internal_columns,
                     );
 
@@ -344,7 +355,6 @@ impl SpacetimeDSLTableMethods {
                             rust_struct,
                             spacetimedb_table,
                             spacetimedsl_table,
-                            primary_key_column_name,
                             internal_columns,
                         )),
                     };
@@ -354,7 +364,6 @@ impl SpacetimeDSLTableMethods {
                         rust_struct,
                         spacetimedb_table,
                         spacetimedsl_table,
-                        primary_key_column_name,
                         internal_columns,
                     );
 
@@ -569,7 +578,6 @@ pub(in crate::internal) fn for_method(
     rust_struct: &RustStruct,
     spacetimedb_table: &SpacetimeDBTable,
     spacetimedsl_table: &SpacetimeDSLTable,
-    primary_key_column_name: &Ident,
     internal_columns: &Vec<InternalColumn>,
 ) -> SpacetimeDSLMethod {
     let struct_name = &rust_struct.name;
@@ -578,6 +586,9 @@ pub(in crate::internal) fn for_method(
     let singular_table_name_pascal_case =
         RenameRule::PascalCase.apply_to_field(singular_table_name.to_string());
     let plural_table_name = &spacetimedsl_table.plural_name;
+
+    let one = OneOrMultiple::One;
+    let multiple = OneOrMultiple::Multiple;
 
     // TODO https://github.com/tamaro-skaljic/SpacetimeDSL/issues/35
     let doc_comment;
@@ -650,7 +661,6 @@ pub(in crate::internal) fn for_method(
                 &struct_name,
                 &singular_table_name,
                 &spacetimedb_table,
-                primary_key_column_name,
                 &column_names_and_row_values,
             );
 
@@ -699,7 +709,7 @@ pub(in crate::internal) fn for_method(
                                 table_name: #singular_table_name_as_string.into(),
                                 action: spacetimedsl::Action::Create,
                                 error_from: spacetimedsl::ErrorFrom::SpacetimeDB,
-                                one_or_multiple: spacetimedsl::OneOrMultiple::One,
+                                one_or_multiple: #one,
                                 column_names_and_row_values: format!("{:?}", #singular_table_name).into(),
                             })
                         }
@@ -932,7 +942,6 @@ pub(in crate::internal) fn for_method(
                         &struct_name,
                         &singular_table_name,
                         &spacetimedb_table,
-                        &primary_key_column_name,
                         &column_names_and_row_values,
                     );
 
@@ -988,7 +997,7 @@ pub(in crate::internal) fn for_method(
                     let reference_integrity_checks = res.1;
 
                     let index_name = match is_multi_column_index {
-                        true => primary_key_column_name,
+                        true => &format_ident!("id"),
                         false => index_name,
                     };
 
@@ -1228,13 +1237,13 @@ pub(in crate::internal) fn for_method(
 
                                 let primary_key_column_values_of_referencing_table = #method_impl_prefix
                                     .filter(#index_name)
-                                    .map(|row| row.#primary_key_column_name)
+                                    .map(|row| row.id)
                                     .collect();
 
                                 if primary_key_column_values_of_referencing_table.is_empty() {
                                     return Ok(spacetimedsl::DeletionResult {
                                         table_name: #singular_table_name_as_string.into(),
-                                        one_or_multiple: spacetimedsl::OneOrMultiple::Multiple,
+                                        one_or_multiple: #multiple,
                                         entries: vec![],
                                     });
                                 }
@@ -1461,8 +1470,8 @@ pub(in crate::internal) fn for_method(
                                         .ctx()
                                         .db()
                                         .#singular_table_name()
-                                        .#primary_key_column_name()
                                         .delete(primary_key_column_value_of_referencing_table) {
+                                        .id()
                                     false => {
                                         return Err(
                                             spacetimedsl::SpacetimeDSLError::Error(
@@ -1473,8 +1482,8 @@ pub(in crate::internal) fn for_method(
                                     true => {
                                         return Ok(spacetimedsl::DeletionResult {
                                             table_name: #singular_table_name_as_string.into(),
-                                            one_or_multiple: spacetimedsl::OneOrMultiple::One,
                                             entries = vec![entry],
+                                            one_or_multiple: #one,
                                         });
                                     },
                                 };
@@ -1715,7 +1724,6 @@ fn multi_column_index_checks(
     struct_name: &Ident,
     singular_table_name: &Ident,
     spacetimedb_table: &SpacetimeDBTable,
-    primary_key_column_name: &Ident,
     column_names_and_row_values: &String,
 ) -> Vec<TokenStream> {
     let mut multi_column_index_checks = vec![];
@@ -1755,13 +1763,15 @@ fn multi_column_index_checks(
 
         let action_as_ident = format_ident!("{action}");
 
+        let multiple = OneOrMultiple::Multiple;
+
         let return_unique_constraint_violation_error = quote! {
             return Err(
                 spacetimedsl::SpacetimeDSLError::UniqueConstraintViolation {
                     table_name: #singular_table_name_as_string.into(),
                     action: spacetimedsl::Action::#action_as_ident,
                     error_from: spacetimedsl::ErrorFrom::SpacetimeDSL,
-                    one_or_multiple: spacetimedsl::OneOrMultiple::Multiple,
+                    one_or_multiple: #multiple,
                     column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*)
                 }
             );
@@ -1773,7 +1783,7 @@ fn multi_column_index_checks(
             }
             Action::Update => {
                 quote! {
-                    if #field_name_for_found_value.#primary_key_column_name.ne(&#singular_table_name.#primary_key_column_name) {
+                    if #field_name_for_found_value.id.ne(&#singular_table_name.id) {
                         #return_unique_constraint_violation_error
                     }
                 }
@@ -1808,6 +1818,8 @@ pub(in crate::internal::dsl::method) fn get_unique_multi_column_index_check(
 
     let action = format_ident!("{action}");
 
+    let multiple = OneOrMultiple::Multiple;
+
     quote! {
         #field_name_for_found_value = match self.ctx().db().#singular_table_name().#index_name().filter((#(#row_value_getters),*)).at_most_one() {
             Ok(#singular_table_name) => #singular_table_name,
@@ -1816,7 +1828,7 @@ pub(in crate::internal::dsl::method) fn get_unique_multi_column_index_check(
                     table_name: #singular_table_name_as_string.into(),
                     action: spacetimedsl::Action::#action,
                     error_from: spacetimedsl::ErrorFrom::SpacetimeDSL,
-                    one_or_multiple: spacetimedsl::OneOrMultiple::Multiple,
+                    one_or_multiple: #multiple,
                     column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*)
                 }
             ),
@@ -1825,7 +1837,7 @@ pub(in crate::internal::dsl::method) fn get_unique_multi_column_index_check(
 }
 
 fn for_referenced_by(
-    dsl_internal_referenced_by_function: DSLInternalReferencedByFunction,
+    one_or_multiple: &OneOrMultiple,
     spacetimedb_table: &SpacetimeDBTable,
     spacetimedsl_table: &SpacetimeDSLTable,
     columns: &Vec<Column>,
@@ -1839,20 +1851,15 @@ fn for_referenced_by(
 
     let primary_key_column = columns
         .iter()
-        .find(|c| c.rust_field.name.eq(primary_key_column_name))
+        .find(|c| c.rust_field.name.to_string().eq(&"id"))
         .expect("should have a primary key");
 
     let primary_key_column_type = &primary_key_column.rust_field.type_name_or_path;
 
     let doc_comment;
-    let trait_name = get_referenced_table_trait_name(
-        &dsl_internal_referenced_by_function,
-        &singular_table_name_pascal_case,
-    );
-    let function_name = get_referenced_table_function_name(
-        &dsl_internal_referenced_by_function,
-        &singular_table_name,
-    );
+    let trait_name =
+        get_referenced_table_trait_name(&one_or_multiple, &singular_table_name_pascal_case);
+    let function_name = get_referenced_table_function_name(&one_or_multiple, &singular_table_name);
 
     let paths_of_traits_to_extend = vec![];
     let mut function_args = vec![
@@ -1872,8 +1879,6 @@ fn for_referenced_by(
 
     let entry_or_entries;
 
-    match dsl_internal_referenced_by_function {
-        DSLInternalReferencedByFunction::ExecuteOnDeleteStrategiesOfReferencingTablesAfterOneRowOfThisTableWasDeleted => {
             doc_comment = format!("Execute On Delete Strategies of all referencing tables after one row of the referenced table `{singular_table_name}` was deleted.");
             entry_or_entries = format_ident!("entry");
             function_args.push(
@@ -1882,6 +1887,8 @@ fn for_referenced_by(
                     arg_name: entry_or_entries.clone(),
                     arg_type: quote! { (&#primary_key_column_type, spacetimedsl::DeletionResultEntry>) }
                 },
+    match one_or_multiple {
+        OneOrMultiple::One => {
             );
             return_type = quote! {
                 Result<
@@ -1890,7 +1897,6 @@ fn for_referenced_by(
                 >
             };
         }
-        DSLInternalReferencedByFunction::ExecuteOnDeleteStrategiesOfReferencingTablesAfterMultipleRowsOfThisTableWereDeleted => {
             doc_comment = format!("Execute On Delete Strategies of all referencing tables after multiple rows of the referenced table `{singular_table_name}` were deleted.");
             entry_or_entries = format_ident!("entries");
             function_args.push(
@@ -1901,6 +1907,7 @@ fn for_referenced_by(
                         std::collections::HashMap<&#primary_key_column_type, spacetimedsl::DeletionResultEntry>
                     }
                 },
+        OneOrMultiple::Multiple => {
             );
             return_type = quote! {
                 Result<
@@ -1918,10 +1925,6 @@ fn for_referenced_by(
     let mut strategy_calls = vec![];
 
     for referencing_table in &spacetimedsl_table.referencing_tables {
-        let dsl_internal_foreign_key_function = get_foreign_key_function_by_referenced_by_function(
-            &dsl_internal_referenced_by_function,
-        );
-
         let referencing_table_name = &referencing_table.table_name;
 
         let referencing_table_name_pascal_case = format_ident!(
@@ -1929,19 +1932,20 @@ fn for_referenced_by(
             RenameRule::PascalCase.apply_to_field(referencing_table_name.to_string())
         );
 
+        let referencing_table_path = &referencing_table.path;
+
         let referencing_table_trait_name = get_referencing_table_trait_name(
-            &dsl_internal_foreign_key_function,
+            &one_or_multiple,
             &referencing_table_name_pascal_case,
             &singular_table_name_pascal_case,
         );
 
         let referencing_table_function_name = get_referencing_table_function_name(
-            &dsl_internal_foreign_key_function,
+            &one_or_multiple,
             &referencing_table_name,
             &singular_table_name,
         );
 
-        let referencing_table_path = &referencing_table.path;
 
         strategy_calls.push(quote! {
             use #referencing_table_path::#referencing_table_trait_name;
@@ -1972,18 +1976,17 @@ fn for_referenced_by(
 }
 
 fn for_foreign_key(
-    dsl_internal_foreign_key_function: DSLInternalForeignKeyFunction,
     rust_struct: &RustStruct,
+    one_or_multiple: &OneOrMultiple,
     spacetimedb_table: &SpacetimeDBTable,
     spacetimedsl_table: &SpacetimeDSLTable,
     columns: &Vec<Column>,
     referenced_table_name: &syn::Ident,
     columns_with_foreign_key: &Vec<&&Column>,
-    primary_key_column_name: &Ident,
 ) -> SpacetimeDSLMethod {
     let primary_key_column_type = &columns
         .iter()
-        .find(|c| c.rust_field.name.eq(primary_key_column_name))
+        .find(|c| c.rust_field.name.to_string().eq(&"id"))
         .expect("should have a primary key")
         .rust_field
         .type_name_or_path;
@@ -1992,7 +1995,6 @@ fn for_foreign_key(
         .first()
         .expect("there should be a column with foreign key");
 
-    let primary_key_column_name = format_ident!("{primary_key_column_name}");
     let referenced_table_primary_key_column_type =
         &first_foreign_key_column.rust_field.type_name_or_path;
 
@@ -2050,13 +2052,13 @@ fn for_foreign_key(
     let doc_comment;
 
     let trait_name = get_referencing_table_trait_name(
-        &dsl_internal_foreign_key_function,
+        &one_or_multiple,
         &singular_table_name_pascal_case,
         &referenced_table_name_pascal_case,
     );
 
     let function_name = get_referencing_table_function_name(
-        &dsl_internal_foreign_key_function,
+        &one_or_multiple,
         &singular_table_name,
         &referenced_table_name,
     );
@@ -2077,13 +2079,9 @@ fn for_foreign_key(
 
     let return_type;
 
-    let one_or_multiple;
     let entry_or_entries;
 
-    match dsl_internal_foreign_key_function {
-        DSLInternalForeignKeyFunction::ExecuteOnDeleteStrategiesOfThisTableAfterOneRowOfTheReferencedTableWasDeleted => {
             doc_comment = format!("Execute On Delete Strategies of the referencing table `{singular_table_name}` after one row of the referenced table `{referenced_table_name}` was deleted.");
-            one_or_multiple = OneOrMultiple::One;
             entry_or_entries = format_ident!("entry");
             function_args.push(
                 SpacetimeDSLMethodArg {
@@ -2091,6 +2089,8 @@ fn for_foreign_key(
                     arg_name: entry_or_entries.clone(),
                     arg_type: quote! { (&#primary_key_column_type, spacetimedsl::DeletionResultEntry>) }
                 },
+    match one_or_multiple {
+        OneOrMultiple::One => {
             );
             return_type = quote! {
                 Result<
@@ -2099,9 +2099,7 @@ fn for_foreign_key(
                 >
             };
         }
-        DSLInternalForeignKeyFunction::ExecuteOnDeleteStrategiesOfThisTableAfterMultipleRowsOfTheReferencedTableWereDeleted => {
             doc_comment = format!("Execute On Delete Strategies of the referencing table `{singular_table_name}` after multiple rows of the referenced table `{referenced_table_name}` were deleted.");
-            one_or_multiple = OneOrMultiple::Multiple;
             entry_or_entries = format_ident!("entries");
             function_args.push(
                 SpacetimeDSLMethodArg {
@@ -2111,6 +2109,7 @@ fn for_foreign_key(
                         std::collections::HashMap<&#primary_key_column_type, spacetimedsl::DeletionResultEntry>
                     }
                 },
+        OneOrMultiple::Multiple => {
             );
             return_type = quote! {
                 Result<
@@ -2141,7 +2140,6 @@ fn for_foreign_key(
             get_on_delete_strategy_implementation(
                 struct_name,
                 singular_table_name,
-                &primary_key_column_name,
                 primary_key_column_type,
                 spacetimedsl_table,
                 on_delete_strategy,
@@ -2173,22 +2171,14 @@ fn for_foreign_key(
     }
 }
 
-#[derive(Debug)]
-pub enum OneOrMultiple {
-    One,
-    Multiple,
-}
-
 fn get_on_delete_strategy_implementation(
     struct_name: &Ident,
     singular_table_name: &Ident,
-    primary_key_column_name: &Ident,
     primary_key_column_type: &Path,
     spacetimedsl_table: &SpacetimeDSLTable,
     on_delete_strategy: &OnDeleteStrategy,
     columns_by_on_delete_strategy: Vec<&&&Column>,
     one_or_multiple: &OneOrMultiple,
-    entry_or_entries: &Ident,
 ) -> TokenStream {
     let mut strategy_before_all_columns = TokenStream::default();
     let mut strategies = vec![];
@@ -2236,10 +2226,6 @@ fn get_on_delete_strategy_implementation(
             &singular_table_name
         );
 
-        let one_or_multiple_as_ident = match one_or_multiple {
-            OneOrMultiple::One => format_ident!("One"),
-            OneOrMultiple::Multiple => format_ident!("Multiple"),
-        };
 
         let get_child_entries = match on_delete_strategy {
             OnDeleteStrategy::Error | OnDeleteStrategy::SetZero | OnDeleteStrategy::Ignore => {
@@ -2304,8 +2290,8 @@ fn get_on_delete_strategy_implementation(
             spacetimedsl::DeletionResultEntry {
                 table_name: #singular_table_name_as_string.into(),
                 column_name: #column_name_as_string.into(),
-                strategy: spacetimedsl::OnDeleteStrategy::#on_delete_strategy,
-                row_value: format!("{}", row.id).into(),
+                strategy: #on_delete_strategy,
+                row_value: format!("{}", id).into(),
                 child_entries,
             }
         };
@@ -2488,59 +2474,75 @@ fn get_foreign_key_function_by_referenced_by_function(
 }
 
 fn get_referenced_table_trait_name(
-    dsl_internal_referenced_by_function: &DSLInternalReferencedByFunction,
+    one_or_multiple: &OneOrMultiple,
     referenced_table_name_pascal_case: &Ident,
 ) -> Ident {
-    match dsl_internal_referenced_by_function {
-        DSLInternalReferencedByFunction::ExecuteOnDeleteStrategiesOfReferencingTablesAfterOneRowOfThisTableWasDeleted => {
-            format_ident!("ExecuteOnDeleteStrategiesOfReferencingTablesAfterOneRowOfThe{referenced_table_name_pascal_case}TableWasDeleted")
-        },
-        DSLInternalReferencedByFunction::ExecuteOnDeleteStrategiesOfReferencingTablesAfterMultipleRowsOfThisTableWereDeleted => {
-            format_ident!("ExecuteOnDeleteStrategiesOfReferencingTablesAfterMultipleRowsOfThe{referenced_table_name_pascal_case}TableWereDeleted")
+    match one_or_multiple {
+        OneOrMultiple::One => {
+            format_ident!(
+                "ExecuteOnDeleteStrategiesOfReferencingTablesAfterOneRowOfThe{referenced_table_name_pascal_case}TableWasDeleted"
+            )
+        }
+        OneOrMultiple::Multiple => {
+            format_ident!(
+                "ExecuteOnDeleteStrategiesOfReferencingTablesAfterMultipleRowsOfThe{referenced_table_name_pascal_case}TableWereDeleted"
+            )
         }
     }
 }
 
 fn get_referenced_table_function_name(
-    dsl_internal_referenced_by_function: &DSLInternalReferencedByFunction,
+    one_or_multiple: &OneOrMultiple,
     referenced_table_name: &Ident,
 ) -> Ident {
-    match dsl_internal_referenced_by_function {
-        DSLInternalReferencedByFunction::ExecuteOnDeleteStrategiesOfReferencingTablesAfterOneRowOfThisTableWasDeleted => {
-            format_ident!("execute_on_delete_strategies_of_referencing_tables_after_one_row_of_the_{referenced_table_name}_table_was_deleted")
-        },
-        DSLInternalReferencedByFunction::ExecuteOnDeleteStrategiesOfReferencingTablesAfterMultipleRowsOfThisTableWereDeleted => {
-            format_ident!("execute_on_delete_strategies_of_referencing_tables_after_multiple_rows_of_the_{referenced_table_name}_table_were_deleted")
+    match one_or_multiple {
+        OneOrMultiple::One => {
+            format_ident!(
+                "execute_on_delete_strategies_of_referencing_tables_after_one_row_of_the_{referenced_table_name}_table_was_deleted"
+            )
+        }
+        OneOrMultiple::Multiple => {
+            format_ident!(
+                "execute_on_delete_strategies_of_referencing_tables_after_multiple_rows_of_the_{referenced_table_name}_table_were_deleted"
+            )
         }
     }
 }
 
 fn get_referencing_table_trait_name(
-    dsl_internal_foreign_key_function: &DSLInternalForeignKeyFunction,
+    one_or_multiple: &OneOrMultiple,
     referencing_table_name_pascal_case: &Ident,
     referenced_table_name_pascal_case: &Ident,
 ) -> Ident {
-    match dsl_internal_foreign_key_function {
-        DSLInternalForeignKeyFunction::ExecuteOnDeleteStrategiesOfThisTableAfterOneRowOfTheReferencedTableWasDeleted => {
-            format_ident!("ExecuteOnDeleteStrategiesOfThe{referencing_table_name_pascal_case}TableAfterOneRowOfThe{referenced_table_name_pascal_case}TableWasDeleted")
-        },
-        DSLInternalForeignKeyFunction::ExecuteOnDeleteStrategiesOfThisTableAfterMultipleRowsOfTheReferencedTableWereDeleted => {
-            format_ident!("ExecuteOnDeleteStrategiesOfThe{referencing_table_name_pascal_case}TableAfterMultipleRowsOfThe{referenced_table_name_pascal_case}TableWereDeleted")
+    match one_or_multiple {
+        OneOrMultiple::One => {
+            format_ident!(
+                "ExecuteOnDeleteStrategiesOfThe{referencing_table_name_pascal_case}TableAfterOneRowOfThe{referenced_table_name_pascal_case}TableWasDeleted"
+            )
+        }
+        OneOrMultiple::Multiple => {
+            format_ident!(
+                "ExecuteOnDeleteStrategiesOfThe{referencing_table_name_pascal_case}TableAfterMultipleRowsOfThe{referenced_table_name_pascal_case}TableWereDeleted"
+            )
         }
     }
 }
 
 fn get_referencing_table_function_name(
-    dsl_internal_foreign_key_function: &DSLInternalForeignKeyFunction,
+    one_or_multiple: &OneOrMultiple,
     referencing_table_name: &Ident,
     referenced_table_name: &Ident,
 ) -> Ident {
-    match dsl_internal_foreign_key_function {
-        DSLInternalForeignKeyFunction::ExecuteOnDeleteStrategiesOfThisTableAfterOneRowOfTheReferencedTableWasDeleted => {
-            format_ident!("execute_on_delete_strategies_of_the_{referencing_table_name}_table_after_one_row_of_the_{referenced_table_name}_table_was_deleted")
-        },
-        DSLInternalForeignKeyFunction::ExecuteOnDeleteStrategiesOfThisTableAfterMultipleRowsOfTheReferencedTableWereDeleted => {
-            format_ident!("execute_on_delete_strategies_of_the_{referencing_table_name}_table_after_multiple_rows_of_the_{referenced_table_name}_table_were_deleted")
+    match one_or_multiple {
+        OneOrMultiple::One => {
+            format_ident!(
+                "execute_on_delete_strategies_of_the_{referencing_table_name}_table_after_one_row_of_the_{referenced_table_name}_table_was_deleted"
+            )
+        }
+        OneOrMultiple::Multiple => {
+            format_ident!(
+                "execute_on_delete_strategies_of_the_{referencing_table_name}_table_after_multiple_rows_of_the_{referenced_table_name}_table_were_deleted"
+            )
         }
     }
 }

--- a/derive-input/src/internal/dsl/method.rs
+++ b/derive-input/src/internal/dsl/method.rs
@@ -46,6 +46,8 @@ pub(in crate::internal) enum DSLMethod<'a> {
 
 // FIXME: Ensure that any panic! / expect() / unwrap() is replaced by proper error handling, either returning spacetimedsl::SpacetimeDSLError during runtime or syn::Error during compilation time
 
+// FIXME: Ensure that struct_name is only used in doc comments, not in generated code
+
 #[derive(Debug)]
 pub enum OneOrMultiple {
     One,
@@ -105,16 +107,6 @@ impl Display for Action {
             Action::Delete => write!(f, "Delete"),
         }
     }
-}
-
-pub(in crate::internal) enum DSLInternalReferencedByFunction {
-    ExecuteOnDeleteStrategiesOfReferencingTablesAfterOneRowOfThisTableWasDeleted,
-    ExecuteOnDeleteStrategiesOfReferencingTablesAfterMultipleRowsOfThisTableWereDeleted,
-}
-
-pub(in crate::internal) enum DSLInternalForeignKeyFunction {
-    ExecuteOnDeleteStrategiesOfThisTableAfterOneRowOfTheReferencedTableWasDeleted,
-    ExecuteOnDeleteStrategiesOfThisTableAfterMultipleRowsOfTheReferencedTableWereDeleted,
 }
 
 impl SpacetimeDSLColumnMethods {
@@ -247,7 +239,6 @@ impl SpacetimeDSLTableMethods {
                 spacetimedb_table,
                 spacetimedsl_table,
                 columns,
-                primary_key_column_name,
             ));
         }
 
@@ -289,10 +280,9 @@ impl SpacetimeDSLTableMethods {
                 .for_each(|(referenced_table_name, columns_with_foreign_key)| {
                     execute_on_delete_strategies_of_this_table_after_one_row_of_the_referenced_table_was_deleted.push(
                         for_foreign_key(
-                            rust_struct,
                             &OneOrMultiple::One,
+                            spacetimedsl_table.referencing_tables.is_empty(),
                             spacetimedb_table,
-                            spacetimedsl_table,
                             columns,
                             referenced_table_name,
                             &columns_with_foreign_key,
@@ -300,10 +290,9 @@ impl SpacetimeDSLTableMethods {
                     );
                     execute_on_delete_strategies_of_this_table_after_multiple_rows_of_the_referenced_table_were_deleted.push(
                         for_foreign_key(
-                            rust_struct,
                             &OneOrMultiple::Multiple,
+                            spacetimedsl_table.referencing_tables.is_empty(),
                             spacetimedb_table,
-                            spacetimedsl_table,
                             columns,
                             referenced_table_name,
                             &columns_with_foreign_key,
@@ -658,7 +647,6 @@ pub(in crate::internal) fn for_method(
 
             let multi_column_index_checks = multi_column_index_checks(
                 Action::Create,
-                &struct_name,
                 &singular_table_name,
                 &spacetimedb_table,
                 &column_names_and_row_values,
@@ -939,7 +927,6 @@ pub(in crate::internal) fn for_method(
 
                     let multi_column_index_checks = multi_column_index_checks(
                         Action::Update,
-                        &struct_name,
                         &singular_table_name,
                         &spacetimedb_table,
                         &column_names_and_row_values,
@@ -1721,7 +1708,6 @@ fn reference_integrity_checks_on_create_or_update(
 
 fn multi_column_index_checks(
     action: Action,
-    struct_name: &Ident,
     singular_table_name: &Ident,
     spacetimedb_table: &SpacetimeDBTable,
     column_names_and_row_values: &String,
@@ -1841,7 +1827,6 @@ fn for_referenced_by(
     spacetimedb_table: &SpacetimeDBTable,
     spacetimedsl_table: &SpacetimeDSLTable,
     columns: &Vec<Column>,
-    primary_key_column_name: &Ident,
 ) -> SpacetimeDSLMethod {
     let singular_table_name = &spacetimedb_table.singular_name;
     let singular_table_name_pascal_case = format_ident!(
@@ -1976,10 +1961,9 @@ fn for_referenced_by(
 }
 
 fn for_foreign_key(
-    rust_struct: &RustStruct,
     one_or_multiple: &OneOrMultiple,
+    has_referenced_bys: bool,
     spacetimedb_table: &SpacetimeDBTable,
-    spacetimedsl_table: &SpacetimeDSLTable,
     columns: &Vec<Column>,
     referenced_table_name: &syn::Ident,
     columns_with_foreign_key: &Vec<&&Column>,
@@ -2035,8 +2019,6 @@ fn for_foreign_key(
             .expect("The key OnDeleteStrategy should exist!")
             .push(column_with_foreign_key);
     }
-
-    let struct_name = &rust_struct.name;
 
     let singular_table_name = &spacetimedb_table.singular_name;
     let singular_table_name_pascal_case = format_ident!(

--- a/derive-input/src/internal/dsl/method.rs
+++ b/derive-input/src/internal/dsl/method.rs
@@ -662,6 +662,7 @@ pub(in crate::internal) fn for_method(
                 &internal_columns,
                 paths_of_traits_to_extend,
                 None,
+                &OneOrMultiple::One,
             );
             paths_of_traits_to_extend = res.0;
             let reference_integrity_checks = res.1;
@@ -970,12 +971,18 @@ pub(in crate::internal) fn for_method(
                         TokenStream::default()
                     };
 
+                    let one_or_multiple = match is_multi_column_index {
+                        false => OneOrMultiple::One,
+                        true => OneOrMultiple::Multiple,
+                    };
+
                     let res = reference_integrity_checks_on_create_or_update(
                         CreateOrUpdate::Update,
                         spacetimedb_table,
                         internal_columns,
                         paths_of_traits_to_extend,
-                        Some(&column_names_and_row_values),
+                        Some((&column_names_and_row_values, &index_columns)),
+                        &one_or_multiple,
                     );
                     paths_of_traits_to_extend = res.0;
                     let reference_integrity_checks = res.1;
@@ -1258,7 +1265,7 @@ pub(in crate::internal) fn for_method(
                                 }
                             };
 
-                                let delete_many_impl = quote! {let count_of_rows_to_delete: u64 = primary_key_values_of_rows_to_delete
+                            let delete_many_impl = quote! {let count_of_rows_to_delete: u64 = primary_key_values_of_rows_to_delete
                                     .len()
                                     .try_into()
                                     .unwrap_or(u64::MAX);
@@ -1435,7 +1442,10 @@ pub(in crate::internal) fn for_method(
                             }
                         },
                         DSLMethod::DeleteOne(_) => {
-                            let get_row_to_delete = match is_multi_column_index {
+                            let get_primary_key_value_of_row_to_delete;
+                            let get_row_to_delete;
+
+                            match is_multi_column_index {
                                 true => {
                                     let multi_column_index_check =
                                         get_unique_multi_column_index_check(
@@ -1446,32 +1456,54 @@ pub(in crate::internal) fn for_method(
                                             &row_value_getters,
                                         );
 
-                                    quote! {
-                                        let #index_name = (#(#row_value_getters),*);
-
+                                    get_row_to_delete = quote! {
                                         let mut #field_name_for_found_value: Option<#struct_name> = None;
 
                                         #multi_column_index_check
 
                                         let row_to_delete = #field_name_for_found_value;
-                                    }
+                                    };
+
+                                    get_primary_key_value_of_row_to_delete = quote! {
+                                        let primary_key_value_of_a_row_to_delete = match row_to_delete {
+                                            None => return Err(
+                                                spacetimedsl::SpacetimeDSLError::NotFoundError {
+                                                    table_name: #singular_table_name_as_string.into(),
+                                                    column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*).into()
+                                                }
+                                            ),
+                                            Some(row_to_delete) => row_to_delete.id,
+                                        };
+                                    };
                                 }
                                 false => {
                                     let column_name = &index_columns[0];
                                     let column_type = &internal_columns.iter().find(|c| c.rust_field_name.eq(column_name)).expect("The index should have a column in the internal columns").rust_field_type_name_or_path;
                                     if column_type.to_token_stream().to_string().eq(&"String") {
-                                        quote! {
+                                        get_row_to_delete = quote! {
                                             let #index_name = #(#row_value_getters),*;
 
                                             let row_to_delete = #method_impl_prefix.find(&#index_name);
                                         }
                                     } else {
-                                        quote! {
+                                        get_row_to_delete = quote! {
                                             let #index_name = #(#row_value_getters),*;
 
                                             let row_to_delete = #method_impl_prefix.find(#index_name);
                                         }
                                     }
+
+                                    get_primary_key_value_of_row_to_delete = quote! {
+                                        let primary_key_value_of_a_row_to_delete = match row_to_delete {
+                                            None => return Err(
+                                                spacetimedsl::SpacetimeDSLError::NotFoundError {
+                                                    table_name: #singular_table_name_as_string.into(),
+                                                    column_names_and_row_values: format!(#column_names_and_row_values, &#index_name).into()
+                                                }
+                                            ),
+                                            Some(row_to_delete) => row_to_delete.id,
+                                        };
+                                    };
                                 }
                             };
 
@@ -1482,15 +1514,7 @@ pub(in crate::internal) fn for_method(
 
                                 #get_row_to_delete
 
-                                let primary_key_value_of_a_row_to_delete = match row_to_delete {
-                                    None => return Err(
-                                        spacetimedsl::SpacetimeDSLError::NotFoundError {
-                                            table_name: #singular_table_name_as_string.into(),
-                                            column_names_and_row_values: format!(#column_names_and_row_values, &#index_name).into()
-                                        }
-                                    ),
-                                    Some(row_to_delete) => row_to_delete.id,
-                                };
+                                #get_primary_key_value_of_row_to_delete
                             };
 
                             let map_primary_key_value_of_a_row_to_delete_to_deletion_result_entry = quote! {
@@ -1704,7 +1728,8 @@ fn reference_integrity_checks_on_create_or_update(
     spacetimedb_table: &SpacetimeDBTable,
     columns: &Vec<InternalColumn>,
     mut paths_of_traits_to_extend: Vec<Path>,
-    column_names_and_row_values: Option<&String>,
+    column_names_and_row_values_and_column_names: Option<(&String, &Vec<Ident>)>,
+    one_or_multiple: &OneOrMultiple,
 ) -> (Vec<Path>, Vec<TokenStream>) {
     let mut reference_integrity_checks = vec![];
 
@@ -1741,6 +1766,7 @@ fn reference_integrity_checks_on_create_or_update(
         let referencing_table_name = &spacetimedb_table.singular_name;
         let referencing_table_name_as_string = referencing_table_name.to_string();
         let referencing_table_column_name = &column.rust_field_name;
+        let referencing_table_column_name_as_string = referencing_table_column_name.to_string();
         let referencing_table_column_getter_name =
             format_ident!("get_{referencing_table_column_name}");
 
@@ -1780,6 +1806,30 @@ fn reference_integrity_checks_on_create_or_update(
                 }
             }
             CreateOrUpdate::Update => {
+                let column_names_and_row_value_getters =
+                    column_names_and_row_values_and_column_names.expect(
+                        "DSLMethod::Update should have column names and row value getters!",
+                    );
+                let column_names_and_row_values = column_names_and_row_value_getters.0;
+                let column_names = column_names_and_row_value_getters.1;
+                let row_value_getters = column_names
+                    .iter()
+                    .map(|cn| {
+                        quote! {
+                            #referencing_table_name.#cn
+                        }
+                    })
+                    .collect_vec();
+
+                let format_for_not_found_error = match one_or_multiple {
+                    OneOrMultiple::One => quote! {
+                        format!(#column_names_and_row_values, #referencing_table_column_name)
+                    },
+                    OneOrMultiple::Multiple => quote! {
+                        format!(#column_names_and_row_values, #(#row_value_getters),*)
+                    },
+                };
+
                 quote! {
                     if #field_name_for_found_value.is_none() {
                         #field_name_for_found_value = match self.ctx().db().#referencing_table_name().id().find(#referencing_table_name.get_id().value()) {
@@ -1788,7 +1838,7 @@ fn reference_integrity_checks_on_create_or_update(
                                 return Err(
                                     spacetimedsl::SpacetimeDSLError::NotFoundError {
                                         table_name: #referencing_table_name_as_string.into(),
-                                        column_names_and_row_values: format!(#column_names_and_row_values, #referencing_table_column_name).into()
+                                        column_names_and_row_values: #format_for_not_found_error.into()
                                     }
                                 );
                             }
@@ -1802,7 +1852,7 @@ fn reference_integrity_checks_on_create_or_update(
                                     spacetimedsl::ReferenceIntegrityViolationError::OnCreateOrUpdate {
                                         table_name: #referencing_table_name_as_string.into(),
                                         create_or_update: spacetimedsl::Action::Update,
-                                        column_names_and_row_values: format!(#column_names_and_row_values, #referencing_table_column_name).into()
+                                        column_names_and_row_values: format!("{{ {} : {} }}", #referencing_table_column_name_as_string, #referencing_table_column_name).into()
                                     }
                                 )
                             )
@@ -1818,14 +1868,19 @@ fn reference_integrity_checks_on_create_or_update(
                     #check
                 }
             },
-            "Option" => quote! {
-                if #referencing_table_column_name.is_some() {
-                    #check
+            column_type => {
+                if column_type.starts_with("Option") {
+                    quote! {
+                        if #referencing_table_column_name.is_some() {
+                            #check
+                        }
+                    }
+                } else {
+                    quote! {
+                        #check
+                    }
                 }
-            },
-            _ => quote! {
-                #check
-            },
+            }
         });
     }
 

--- a/derive-input/src/internal/dsl/method.rs
+++ b/derive-input/src/internal/dsl/method.rs
@@ -1385,6 +1385,7 @@ pub(in crate::internal) fn for_method(
                         }
                         DSLMethod::GetOneOption(_) => match is_multi_column_index {
                             true => {
+                                // FIXME: Row Value Getters of Wrapper Types shouldn't be `id.clone().into().value()`, they should be `let id = id.into();` at the method beginning and then `id.value()` anywhere else
                                 let multi_column_index_check = get_unique_multi_column_index_check(
                                     &Action::Get,
                                     &singular_table_name,
@@ -1766,8 +1767,8 @@ fn reference_integrity_checks_on_create_or_update(
             CreateOrUpdate::Create => {
                 quote! {
                     match self.#get_row_of_referenced_table_by_primary_key_method_name(#referencing_table_name.#referencing_table_column_getter_name()) {
-                        Some(_) => {},
-                        None => {
+                        Ok(_) => {},
+                        Err(_) => {
                             return Err(
                                 spacetimedsl::SpacetimeDSLError::ReferenceIntegrityViolation(
                                     spacetimedsl::ReferenceIntegrityViolationError::OnCreateOrUpdate {
@@ -1802,8 +1803,8 @@ fn reference_integrity_checks_on_create_or_update(
                     }
                     if #field_name_for_found_value.as_ref().unwrap().#referencing_table_column_getter_name().ne(&#referencing_table_name.#referencing_table_column_getter_name()) {
                         match self.#get_row_of_referenced_table_by_primary_key_method_name(#referencing_table_name.#referencing_table_column_getter_name()) {
-                            Some(_) => {},
-                            None => return Err(
+                            Ok(_) => {},
+                            Err(_) => return Err(
                                 spacetimedsl::SpacetimeDSLError::ReferenceIntegrityViolation(
                                     spacetimedsl::ReferenceIntegrityViolationError::OnCreateOrUpdate {
                                         table_name: #referencing_table_name_as_string.into(),

--- a/derive-input/src/internal/dsl/method.rs
+++ b/derive-input/src/internal/dsl/method.rs
@@ -1222,12 +1222,12 @@ pub(in crate::internal) fn for_method(
 
                                 #let_index_name
 
-                                let primary_key_column_values_of_referencing_table = #method_impl_prefix
+                                let primary_key_values_of_rows_to_delete = #method_impl_prefix
                                     .filter(#index_name)
                                     .map(|row| row.id)
                                     .collect();
 
-                                if primary_key_column_values_of_referencing_table.is_empty() {
+                                if primary_key_values_of_rows_to_delete.is_empty() {
                                     return Ok(spacetimedsl::DeletionResult {
                                         table_name: #singular_table_name_as_string.into(),
                                         one_or_multiple: #multiple,
@@ -1236,17 +1236,17 @@ pub(in crate::internal) fn for_method(
                                 }
                             };
 
-                            let map_primary_key_column_values_of_referencing_table_to_deletion_result_entries = quote! {
-                                let mut entries = std::collections::HashMap::new();
+                            let map_primary_key_values_of_rows_to_delete_to_deletion_result_entries = quote! {
+                                let mut deletion_result_entries = std::collections::HashMap::new();
 
-                                for primary_key_column_value_of_referencing_table in &primary_key_column_values_of_referencing_table {
-                                    entries.insert(
-                                        primary_key_column_value_of_referencing_table,
+                                for primary_key_value_of_a_row_to_delete in &primary_key_values_of_rows_to_delete {
+                                    deletion_result_entries.insert(
+                                        primary_key_value_of_a_row_to_delete,
                                         spacetimedsl::DeletionResultEntry {
                                             table_name: #singular_table_name_as_string.into(),
                                             column_name: "id".into(),
                                             strategy: spacetimedsl::OnDeleteStrategy::Delete,
-                                            row_value: format!("{primary_key_column_value_of_referencing_table}").into(),
+                                            row_value: format!("{primary_key_value_of_a_row_to_delete}").into(),
                                             child_entries: vec![],
                                         }
                                     );
@@ -1254,7 +1254,7 @@ pub(in crate::internal) fn for_method(
                             };
 
                             let delete_many_and_return_result_impl = quote! {
-                                let count_of_rows_to_delete = primary_key_column_values_of_referencing_table.len();
+                                let count_of_rows_to_delete = primary_key_values_of_rows_to_delete.len();
                                 let count_of_deleted_rows = #method_impl_prefix.delete(#index_name);
 
                                 if count_of_rows_to_delete.ne(&count_of_deleted_rows) {
@@ -1271,8 +1271,8 @@ pub(in crate::internal) fn for_method(
 
                                 return Ok(spacetimedsl::DeletionResult {
                                     table_name: #singular_table_name_as_string.into(),
-                                    one_or_multiple: spacetimedsl::OneOrMultiple::Multiple,
-                                    entries: entries.into_values().collect_vec(),
+                                    one_or_multiple: #multiple,
+                                    entries: deletion_result_entries.into_values().collect_vec(),
                                 });
                             };
 
@@ -1280,66 +1280,101 @@ pub(in crate::internal) fn for_method(
                                 method_impl = quote! {
                                     #impl_until_return_ok_on_is_empty
 
-                                    #map_primary_key_column_values_of_referencing_table_to_deletion_result_entries
+                                    #map_primary_key_values_of_rows_to_delete_to_deletion_result_entries
 
                                     #delete_many_and_return_result_impl
                                 };
                             } else {
-                                let referenced_table_function_name = get_referenced_table_function_name(
-                                    &DSLInternalReferencedByFunction::ExecuteOnDeleteStrategiesOfReferencingTablesAfterMultipleRowsOfThisTableWereDeleted,
-                                    &singular_table_name
-                                );
+                                let error_strategy =
+                                    get_referenced_table_function_call_for_dsl_method(
+                                        singular_table_name,
+                                        &singular_table_name_as_string,
+                                        OnDeleteStrategy::Error,
+                                        OneOrMultiple::Multiple,
+                                    );
+
+                                let delete_strategy =
+                                    get_referenced_table_function_call_for_dsl_method(
+                                        singular_table_name,
+                                        &singular_table_name_as_string,
+                                        OnDeleteStrategy::Delete,
+                                        OneOrMultiple::Multiple,
+                                    );
+
+                                /* TODO
+                                                               let set_none_strategy =
+                                                                   get_referenced_table_function_call_for_dsl_method(
+                                                                       singular_table_name,
+                                                                       &singular_table_name_as_string,
+                                                                       OnDeleteStrategy::SetNone,
+                                                                       OneOrMultiple::Multiple,
+                                                                   );
+                                */
+
+                                let set_zero_strategy =
+                                    get_referenced_table_function_call_for_dsl_method(
+                                        singular_table_name,
+                                        &singular_table_name_as_string,
+                                        OnDeleteStrategy::SetZero,
+                                        OneOrMultiple::Multiple,
+                                    );
+
+                                let ignore_strategy =
+                                    get_referenced_table_function_call_for_dsl_method(
+                                        singular_table_name,
+                                        &singular_table_name_as_string,
+                                        OnDeleteStrategy::Ignore,
+                                        OneOrMultiple::Multiple,
+                                    );
+
+                                let special_error_handler = quote! {
+                                    match error {
+                                        None => {},
+                                        Some(error) => {
+                                            return Err(
+                                                spacetimedsl::SpacetimeDSLError::Error(
+                                                    format!("Delete Many Error: An unknown error occurred after changing the database state! If the reducer running this doesn't return an error, the state changes are persisted and you have problems now! Here is the deletion result: {error}")
+                                                )
+                                            );
+                                        }
+                                    };
+                                };
 
                                 method_impl = quote! {
                                     #impl_until_return_ok_on_is_empty
 
-                                    #map_primary_key_column_values_of_referencing_table_to_deletion_result_entries
+                                    #map_primary_key_values_of_rows_to_delete_to_deletion_result_entries
 
-                                    match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::Error, entries) {
-                                        Err(e) => {
-                                            return Err(spacetimedsl::DeletionResult {
-                                                table_name: #singular_table_name_as_string.into(),
-                                                one_or_multiple: spacetimedsl::OneOrMultiple::Multiple,
-                                                entries: e.into_values().collect_vec(),
-                                            });
-                                        },
-                                        Ok(e) => entries = e,
+                                    let mut error: Option<spacetimedsl::DeletionResult> = None;
+
+                                    #error_strategy
+
+                                    match error {
+                                        None => {},
+                                        Some(error) => {
+                                            return Err(
+                                                spacetimedsl::SpacetimeDSLError::ReferenceIntegrityViolation(
+                                                    spacetimedsl::ReferenceIntegrityViolationError::OnDelete(error)
+                                                )
+                                            );
+                                        }
                                     };
 
-                                    match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::Delete, entries) {
-                                        Err(e) => {
-                                            return Err(spacetimedsl::DeletionResult {
-                                                table_name: #singular_table_name_as_string.into(),
-                                                one_or_multiple: spacetimedsl::OneOrMultiple::Multiple,
-                                                entries: e.into_values().collect_vec(),
-                                            });
-                                        },
-                                        Ok(e) => entries = e,
-                                    };
+                                    // FIXME: Delete initial rows after success of error strategy
 
-                                    /* // FIXME: If SetNone is implemented
-                                    match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::SetNone, entry) {
-                                        Err(e) => {
-                                            return Err(spacetimedsl::DeletionResult {
-                                                table_name: #singular_table_name_as_string.into(),
-                                                one_or_multiple: spacetimedsl::OneOrMultiple::Multiple,
-                                                entries: e.into_values().collect_vec(),
-                                            });
-                                        },
-                                        Ok(e) => entries = e,
-                                    };
-                                    */
+                                    #delete_strategy
 
-                                    match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::SetZero, entries) {
-                                        Err(e) => {
-                                            return Err(spacetimedsl::DeletionResult {
-                                                table_name: #singular_table_name_as_string.into(),
-                                                one_or_multiple: spacetimedsl::OneOrMultiple::Multiple,
-                                                entries: e.into_values().collect_vec(),
-                                            });
-                                        },
-                                        Ok(e) => entries = e,
-                                    };
+                                    #special_error_handler
+
+                                    //TODO #set_none_strategy
+
+                                    // TODO #special_error_handler
+
+                                    #set_zero_strategy
+
+                                    #special_error_handler
+
+                                    #ignore_strategy
 
                                     #delete_many_and_return_result_impl
                                 };
@@ -1394,7 +1429,7 @@ pub(in crate::internal) fn for_method(
                             }
                         },
                         DSLMethod::DeleteOne(_) => {
-                            let get_primary_key_column_value_of_referencing_table =
+                            let get_primary_key_value_of_a_row_to_delete =
                                 match is_multi_column_index {
                                     true => {
                                         let multi_column_index_check =
@@ -1415,13 +1450,13 @@ pub(in crate::internal) fn for_method(
 
                                             #multi_column_index_check
 
-                                            let primary_key_column_value_of_referencing_table = #field_name_for_found_value;
+                                            let primary_key_value_of_a_row_to_delete = #field_name_for_found_value;
                                         }
                                     }
                                     false => quote! {
                                         let #index_name = #(#row_value_getters),*;
 
-                                        let primary_key_column_value_of_referencing_table = #method_impl_prefix.find(#index_name);
+                                        let primary_key_value_of_a_row_to_delete = #method_impl_prefix.find(#index_name);
                                     },
                                 };
 
@@ -1430,26 +1465,27 @@ pub(in crate::internal) fn for_method(
 
                                 #(#wrapper_type_option_to_wrapped_type_option_mappers)*
 
-                                #get_primary_key_column_value_of_referencing_table
+                                #get_primary_key_value_of_a_row_to_delete
 
-                                let primary_key_column_value_of_referencing_table = match primary_key_column_value_of_referencing_table {
-                                    None => return Err(spacetimedsl::DeletionResult {
-                                        table_name: #singular_table_name_as_string.into(),
-                                        one_or_multiple: spacetimedsl::OneOrMultiple::One,
-                                        entries: vec![],
-                                    }),
-                                    Some(primary_key_column_value_of_referencing_table) => primary_key_column_value_of_referencing_table,
+                                let primary_key_value_of_a_row_to_delete = match primary_key_value_of_a_row_to_delete {
+                                    None => return Err(
+                                        spacetimedsl::SpacetimeDSLError::NotFoundError {
+                                            table_name: #singular_table_name_as_string,
+                                            column_names_and_row_values: format!(#column_names_and_row_values, #(#row_value_getters),*)
+                                        }
+                                    );,
+                                    Some(primary_key_value_of_a_row_to_delete) => primary_key_value_of_a_row_to_delete,
                                 };
                             };
 
-                            let map_primary_key_column_value_of_referencing_table_to_deletion_result_entry = quote! {
-                                let mut entry = (&primary_key_column_value_of_referencing_table, spacetimedsl::DeletionResultEntry {
+                            let map_primary_key_value_of_a_row_to_delete_to_deletion_result_entry = quote! {
+                                let mut deletion_result_entry = spacetimedsl::DeletionResultEntry {
                                     table_name: #singular_table_name_as_string.into(),
                                     column_name: "id".into(),
                                     strategy: spacetimedsl::OnDeleteStrategy::Delete,
-                                    row_value: format!("{primary_key_column_value_of_referencing_table}").into(),
+                                    row_value: format!("{primary_key_value_of_a_row_to_delete}").into(),
                                     child_entries: vec![],
-                                });
+                                };
                             };
 
                             let delete_one_and_return_result_impl = quote! {
@@ -1457,8 +1493,8 @@ pub(in crate::internal) fn for_method(
                                         .ctx()
                                         .db()
                                         .#singular_table_name()
-                                        .delete(primary_key_column_value_of_referencing_table) {
                                         .id()
+                                        .delete(primary_key_value_of_a_row_to_delete) {
                                     false => {
                                         return Err(
                                             spacetimedsl::SpacetimeDSLError::Error(
@@ -1469,8 +1505,8 @@ pub(in crate::internal) fn for_method(
                                     true => {
                                         return Ok(spacetimedsl::DeletionResult {
                                             table_name: #singular_table_name_as_string.into(),
-                                            entries = vec![entry],
                                             one_or_multiple: #one,
+                                            entries = vec![deletion_result_entry],
                                         });
                                     },
                                 };
@@ -1480,66 +1516,101 @@ pub(in crate::internal) fn for_method(
                                 method_impl = quote! {
                                     #impl_until_return_err_on_is_none
 
-                                    #map_primary_key_column_value_of_referencing_table_to_deletion_result_entry
+                                    #map_primary_key_value_of_a_row_to_delete_to_deletion_result_entry
 
                                     #delete_one_and_return_result_impl
                                 };
                             } else {
-                                let referenced_table_function_name = get_referenced_table_function_name(
-                                    &DSLInternalReferencedByFunction::ExecuteOnDeleteStrategiesOfReferencingTablesAfterOneRowOfThisTableWasDeleted,
-                                    &singular_table_name
-                                );
+                                let error_strategy =
+                                    get_referenced_table_function_call_for_dsl_method(
+                                        singular_table_name,
+                                        &singular_table_name_as_string,
+                                        OnDeleteStrategy::Error,
+                                        OneOrMultiple::One,
+                                    );
+
+                                let delete_strategy =
+                                    get_referenced_table_function_call_for_dsl_method(
+                                        singular_table_name,
+                                        &singular_table_name_as_string,
+                                        OnDeleteStrategy::Delete,
+                                        OneOrMultiple::One,
+                                    );
+
+                                /* TODO
+                                                               let set_none_strategy =
+                                                                   get_referenced_table_function_call_for_dsl_method(
+                                                                       singular_table_name,
+                                                                       &singular_table_name_as_string,
+                                                                       OnDeleteStrategy::SetNone,
+                                                                       OneOrMultiple::One,
+                                                                   );
+                                */
+
+                                let set_zero_strategy =
+                                    get_referenced_table_function_call_for_dsl_method(
+                                        singular_table_name,
+                                        &singular_table_name_as_string,
+                                        OnDeleteStrategy::SetZero,
+                                        OneOrMultiple::One,
+                                    );
+
+                                let ignore_strategy =
+                                    get_referenced_table_function_call_for_dsl_method(
+                                        singular_table_name,
+                                        &singular_table_name_as_string,
+                                        OnDeleteStrategy::Ignore,
+                                        OneOrMultiple::One,
+                                    );
+
+                                let special_error_handler = quote! {
+                                    match error {
+                                        None => {},
+                                        Some(error) => {
+                                            return Err(
+                                                spacetimedsl::SpacetimeDSLError::Error(
+                                                    format!("Delete One Error: An unknown error occurred after changing the database state! If the reducer running this doesn't return an error, the state changes are persisted and you have problems now! Here is the deletion result: {error}")
+                                                )
+                                            );
+                                        }
+                                    };
+                                };
 
                                 method_impl = quote! {
                                     #impl_until_return_err_on_is_none
 
-                                    #map_primary_key_column_value_of_referencing_table_to_deletion_result_entry
+                                    #map_primary_key_value_of_a_row_to_delete_to_deletion_result_entry
 
-                                    match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::Error, entry) {
-                                        Err(e) => {
-                                            return Err(spacetimedsl::DeletionResult {
-                                                table_name: #singular_table_name_as_string.into(),
-                                                one_or_multiple: spacetimedsl::OneOrMultiple::One,
-                                                entries: vec![entry],
-                                            });
-                                        },
-                                        Ok(e) => entry = e,
+                                    let mut error: Option<spacetimedsl::DeletionResult> = None;
+
+                                    #error_strategy
+
+                                    match error {
+                                        None => {},
+                                        Some(error) => {
+                                            return Err(
+                                                spacetimedsl::SpacetimeDSLError::ReferenceIntegrityViolation(
+                                                    spacetimedsl::ReferenceIntegrityViolationError::OnDelete(error)
+                                                )
+                                            );
+                                        }
                                     };
 
-                                    match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::Delete, entry) {
-                                        Err(e) => {
-                                            return Err(spacetimedsl::DeletionResult {
-                                                table_name: #singular_table_name_as_string.into(),
-                                                one_or_multiple: spacetimedsl::OneOrMultiple::One,
-                                                entries: vec![entry],
-                                            });
-                                        },
-                                        Ok(e) => entry = e,
-                                    };
+                                    // FIXME: Delete initial row after success of error strategy
 
-                                    /* // FIXME: If SetNone is implemented
-                                    match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::SetNone, entry) {
-                                        Err(e) => {
-                                            return Err(spacetimedsl::DeletionResult {
-                                                table_name: #singular_table_name_as_string.into(),
-                                                one_or_multiple: spacetimedsl::OneOrMultiple::One,
-                                                entries: vec![entry],
-                                            });
-                                        },
-                                        Ok(e) => entry = e,
-                                    };
-                                    */
+                                    #delete_strategy
 
-                                    match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::SetZero, entry) {
-                                        Err(e) => {
-                                            return Err(spacetimedsl::DeletionResult {
-                                                table_name: #singular_table_name_as_string.into(),
-                                                one_or_multiple: spacetimedsl::OneOrMultiple::One,
-                                                entries: vec![entry],
-                                            });
-                                        },
-                                        Ok(e) => entry = e,
-                                    };
+                                    #special_error_handler
+
+                                    //TODO #set_none_strategy
+
+                                    // TODO #special_error_handler
+
+                                    #set_zero_strategy
+
+                                    #special_error_handler
+
+                                    #ignore_strategy
 
                                     #delete_one_and_return_result_impl
                                 };
@@ -1565,6 +1636,62 @@ pub(in crate::internal) fn for_method(
         method_args,
         return_type,
         method_impl,
+    }
+}
+
+fn get_referenced_table_function_call_for_dsl_method(
+    singular_table_name: &Ident,
+    singular_table_name_as_string: &String,
+    on_delete_strategy: OnDeleteStrategy,
+    one_or_multiple: OneOrMultiple,
+) -> TokenStream {
+    match one_or_multiple {
+        OneOrMultiple::One => {
+            let referenced_table_function_name =
+                get_referenced_table_function_name(&OneOrMultiple::One, &singular_table_name);
+
+            quote! {
+                match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), #on_delete_strategy, primary_key_value_of_a_row_to_delete) {
+                    Err(child_entries) => {
+                        deletion_result_entry.child_entries.append(child_entries);
+
+                        error = Some(spacetimedsl::DeletionResult {
+                            table_name: #singular_table_name_as_string.into(),
+                            one_or_multiple: #one_or_multiple,
+                            entries: vec![deletion_result_entry],
+                        });
+                    },
+                    Ok(child_entries) => {
+                        deletion_result_entry.child_entries.append(child_entries);
+                    }
+                };
+            }
+        }
+        OneOrMultiple::Multiple => {
+            let referenced_table_function_name =
+                get_referenced_table_function_name(&OneOrMultiple::Multiple, &singular_table_name);
+
+            quote! {
+                match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), #on_delete_strategy, primary_key_values_of_rows_to_delete) {
+                    Err(child_entries_by_primary_key_value_of_a_row_to_delete) => {
+                        for (primary_key_value_of_a_row_to_delete, child_entries) in child_entries_by_primary_key_value_of_a_row_to_delete {
+                            deletion_result_entries.get_mut(primary_key_value_of_a_row_to_delete).child_entries.append(child_entries);
+                        }
+
+                        error = Some(spacetimedsl::DeletionResult {
+                            table_name: #singular_table_name_as_string.into(),
+                            one_or_multiple: #one_or_multiple,
+                            entries: deletion_result_entries.into_values().collect_vec(),
+                        });
+                    },
+                    Ok(child_entries_by_primary_key_value_of_a_row_to_delete) => {
+                        for (primary_key_value_of_a_row_to_delete, child_entries) in child_entries_by_primary_key_value_of_a_row_to_delete {
+                            deletion_result_entries.get_mut(primary_key_value_of_a_row_to_delete).child_entries.append(child_entries);
+                        }
+                    }
+                };
+            }
+        }
     }
 }
 
@@ -1862,42 +1989,39 @@ fn for_referenced_by(
 
     let return_type;
 
-    let entry_or_entries;
+    let arg_name;
 
-            doc_comment = format!("Execute On Delete Strategies of all referencing tables after one row of the referenced table `{singular_table_name}` was deleted.");
-            entry_or_entries = format_ident!("entry");
-            function_args.push(
-                SpacetimeDSLMethodArg {
-                    is_mut: true,
-                    arg_name: entry_or_entries.clone(),
-                    arg_type: quote! { (&#primary_key_column_type, spacetimedsl::DeletionResultEntry>) }
-                },
     match one_or_multiple {
         OneOrMultiple::One => {
+            doc_comment = format!(
+                "Execute On Delete Strategies of all referencing tables after one row of the referenced table `{singular_table_name}` was deleted."
             );
+            arg_name = format_ident!("primary_key_value_of_a_row_to_delete");
+            function_args.push(SpacetimeDSLMethodArg {
+                is_mut: false,
+                arg_name: arg_name.clone(),
+                arg_type: quote! { &#primary_key_column_type },
+            });
             return_type = quote! {
-                Result<
-                    (&#primary_key_column_type, spacetimedsl::DeletionResultEntry>),
-                    (&#primary_key_column_type, spacetimedsl::DeletionResultEntry>)
-                >
+                Result<Vec<spacetimedsl::DeletionResultEntry>, Vec<spacetimedsl::DeletionResultEntry>>
             };
         }
-            doc_comment = format!("Execute On Delete Strategies of all referencing tables after multiple rows of the referenced table `{singular_table_name}` were deleted.");
-            entry_or_entries = format_ident!("entries");
-            function_args.push(
-                SpacetimeDSLMethodArg {
-                    is_mut: true,
-                    arg_name: entry_or_entries.clone(),
-                    arg_type: quote! {
-                        std::collections::HashMap<&#primary_key_column_type, spacetimedsl::DeletionResultEntry>
-                    }
-                },
         OneOrMultiple::Multiple => {
+            doc_comment = format!(
+                "Execute On Delete Strategies of all referencing tables after multiple rows of the referenced table `{singular_table_name}` were deleted."
             );
+            arg_name = format_ident!("primary_key_values_of_rows_to_delete");
+            function_args.push(SpacetimeDSLMethodArg {
+                is_mut: false,
+                arg_name: arg_name.clone(),
+                arg_type: quote! {
+                    Vec<&#primary_key_column_type>
+                },
+            });
             return_type = quote! {
                 Result<
-                    std::collections::HashMap<&#primary_key_column_type, spacetimedsl::DeletionResultEntry>,
-                    std::collections::HashMap<&#primary_key_column_type, spacetimedsl::DeletionResultEntry>
+                    std::collections::HashMap<&#primary_key_column_type, Vec<spacetimedsl::DeletionResultEntry>>,
+                    std::collections::HashMap<&#primary_key_column_type, Vec<spacetimedsl::DeletionResultEntry>>
                 >
             };
         }
@@ -1905,7 +2029,21 @@ fn for_referenced_by(
 
     let doc_comment = doc_comment.into();
 
-    let function_impl;
+    let create_entries = match one_or_multiple {
+        OneOrMultiple::One => {
+            quote! {
+                let mut entries = vec![];
+            }
+        }
+        OneOrMultiple::Multiple => {
+            quote! {
+                let mut entries = std::collections::HashMap::new();
+                for primary_key_value_of_a_row_to_delete in primary_key_values_of_rows_to_delete {
+                    entries.insert(primary_key_value_of_a_row_to_delete, vec![]);
+                }
+            }
+        }
+    };
 
     let mut strategy_calls = vec![];
 
@@ -1931,22 +2069,60 @@ fn for_referenced_by(
             &singular_table_name,
         );
 
+        strategy_calls.push(
+            match one_or_multiple {
+                OneOrMultiple::One => {
+                    quote! {
+                        use #referencing_table_path::#referencing_table_trait_name;
 
-        strategy_calls.push(quote! {
-            use #referencing_table_path::#referencing_table_trait_name;
-            match spacetimedsl::internal::DSLInternals::#referencing_table_function_name(ctx, &strategy, #entry_or_entries) {
-                Err(e) => {
-                    return Err(#entry_or_entries);
+                        match spacetimedsl::internal::DSLInternals::#referencing_table_function_name(ctx, &strategy, #arg_name) {
+                            Err(child_entries) => {
+                                entries.append(child_entries);
+
+                                error = true;
+                            },
+                            Ok(child_entries) => {
+                                entries.append(child_entries);
+                            },
+                        };
+                    }
                 },
-                Ok(e) => #entry_or_entries = e,
-            };
-        });
+                OneOrMultiple::Multiple => {
+                    quote! {
+                        use #referencing_table_path::#referencing_table_trait_name;
+
+                        match spacetimedsl::internal::DSLInternals::#referencing_table_function_name(ctx, &strategy, #arg_name) {
+                            Err(child_entries_by_primary_key_value_of_a_row_to_delete) => {
+                                for (primary_key_value_of_a_row_to_delete, child_entries) in child_entries_by_primary_key_value_of_a_row_to_delete {
+                                    entries.get_mut(primary_key_value_of_a_row_to_delete).child_entries.append(child_entries);
+                                }
+
+                                error = true;
+                            },
+                            Ok(child_entries_by_primary_key_value_of_a_row_to_delete) => {
+                                for (primary_key_value_of_a_row_to_delete, child_entries) in child_entries_by_primary_key_value_of_a_row_to_delete {
+                                    entries.get_mut(primary_key_value_of_a_row_to_delete).child_entries.append(child_entries);
+                                }
+                            },
+                        };
+                    }
+                },
+            }
+        );
     }
 
-    function_impl = quote! {
+    let function_impl = quote! {
+
+        #create_entries
+
+        let mut error = false;
+
         #(#strategy_calls)*
 
-        Ok(#entry_or_entries)
+        match error {
+            false => Ok(entries),
+            true => Err(entries),
+        }
     };
 
     SpacetimeDSLMethod {
@@ -2061,85 +2237,105 @@ fn for_foreign_key(
 
     let return_type;
 
-    let entry_or_entries;
+    let arg_name;
 
-            doc_comment = format!("Execute On Delete Strategies of the referencing table `{singular_table_name}` after one row of the referenced table `{referenced_table_name}` was deleted.");
-            entry_or_entries = format_ident!("entry");
-            function_args.push(
-                SpacetimeDSLMethodArg {
-                    is_mut: true,
-                    arg_name: entry_or_entries.clone(),
-                    arg_type: quote! { (&#primary_key_column_type, spacetimedsl::DeletionResultEntry>) }
-                },
     match one_or_multiple {
         OneOrMultiple::One => {
+            doc_comment = format!(
+                "Execute On Delete Strategies of the referencing table `{singular_table_name}` after one row of the referenced table `{referenced_table_name}` was deleted."
             );
+            arg_name = format_ident!("primary_key_value_of_a_row_of_another_table_to_delete");
+            function_args.push(SpacetimeDSLMethodArg {
+                is_mut: false,
+                arg_name: arg_name.clone(),
+                arg_type: quote! { &#primary_key_column_type },
+            });
             return_type = quote! {
-                Result<
-                    (&#primary_key_column_type, spacetimedsl::DeletionResultEntry>),
-                    (&#primary_key_column_type, spacetimedsl::DeletionResultEntry>)
-                >
+                Result<Vec<spacetimedsl::DeletionResultEntry>, Vec<spacetimedsl::DeletionResultEntry>>
             };
         }
-            doc_comment = format!("Execute On Delete Strategies of the referencing table `{singular_table_name}` after multiple rows of the referenced table `{referenced_table_name}` were deleted.");
-            entry_or_entries = format_ident!("entries");
-            function_args.push(
-                SpacetimeDSLMethodArg {
-                    is_mut: true,
-                    arg_name: entry_or_entries.clone(),
-                    arg_type: quote! {
-                        std::collections::HashMap<&#primary_key_column_type, spacetimedsl::DeletionResultEntry>
-                    }
-                },
         OneOrMultiple::Multiple => {
+            doc_comment = format!(
+                "Execute On Delete Strategies of the referencing table `{singular_table_name}` after multiple rows of the referenced table `{referenced_table_name}` were deleted."
             );
+            arg_name = format_ident!("primary_key_values_of_rows_of_another_table_to_delete");
+            function_args.push(SpacetimeDSLMethodArg {
+                is_mut: false,
+                arg_name: arg_name.clone(),
+                arg_type: quote! {
+                    Vec<&#primary_key_column_type>
+                },
+            });
             return_type = quote! {
                 Result<
-                    std::collections::HashMap<&#primary_key_column_type, spacetimedsl::DeletionResultEntry>,
-                    std::collections::HashMap<&#primary_key_column_type, spacetimedsl::DeletionResultEntry>
+                    std::collections::HashMap<&#primary_key_column_type, Vec<spacetimedsl::DeletionResultEntry>>,
+                    std::collections::HashMap<&#primary_key_column_type, Vec<spacetimedsl::DeletionResultEntry>>
                 >
             };
         }
     };
 
     let doc_comment = doc_comment.into();
-    let function_impl;
 
-    let mut on_delete_strategy_match_arms = HashMap::new();
+    let create_data_structure_for_child_entries = match one_or_multiple {
+        OneOrMultiple::One => {
+            quote! {
+                let mut entries = vec![];
+            }
+        }
+        OneOrMultiple::Multiple => {
+            quote! {
+                let mut entries = std::collections::HashMap::new();
+                for primary_key_value_of_a_row_of_another_table_to_delete in primary_key_values_of_rows_of_another_table_to_delete {
+                    entries.insert(primary_key_value_of_a_row_of_another_table_to_delete, vec![]);
+                }
+            }
+        }
+    };
+
+    let mut strategy_implementations = HashMap::new();
 
     for on_delete_strategy in OnDeleteStrategy::iter() {
-        on_delete_strategy_match_arms.insert(
-            on_delete_strategy.clone(),
-            quote! {
-                #on_delete_strategy => { }
-            },
-        );
+        strategy_implementations.insert(on_delete_strategy.clone(), TokenStream::default());
     }
 
     for (on_delete_strategy, columns_by_on_delete_strategy) in columns_by_on_delete_strategies {
-        on_delete_strategy_match_arms.insert(
+        strategy_implementations.insert(
             on_delete_strategy.clone(),
             get_on_delete_strategy_implementation(
-                struct_name,
+                has_referenced_bys,
                 singular_table_name,
-                primary_key_column_type,
-                spacetimedsl_table,
                 on_delete_strategy,
                 columns_by_on_delete_strategy,
                 &one_or_multiple,
-                &entry_or_entries,
             ),
         );
     }
 
-    let on_delete_strategy_match_arms = on_delete_strategy_match_arms.values().collect_vec();
+    let strategy_implementations = strategy_implementations
+        .iter()
+        .map(|(on_delete_strategy, implementation)| {
+            quote! {
+                #on_delete_strategy => {
+                    #implementation
+                },
+            }
+        })
+        .collect_vec();
 
-    function_impl = quote! {
+    let function_impl = quote! {
+        #create_data_structure_for_child_entries
+
+        let mut error = false;
+
         match &strategy {
-            #(#on_delete_strategy_match_arms),*
+            #(#strategy_implementations)*
         };
 
-        Ok(#entry_or_entries)
+        match error {
+            false => Ok(entries),
+            true => Err(entries),
+        }
     };
 
     SpacetimeDSLMethod {
@@ -2154,19 +2350,23 @@ fn for_foreign_key(
 }
 
 fn get_on_delete_strategy_implementation(
-    struct_name: &Ident,
+    has_referenced_bys: bool,
     singular_table_name: &Ident,
-    primary_key_column_type: &Path,
-    spacetimedsl_table: &SpacetimeDSLTable,
     on_delete_strategy: &OnDeleteStrategy,
     columns_by_on_delete_strategy: Vec<&&&Column>,
     one_or_multiple: &OneOrMultiple,
 ) -> TokenStream {
-    let mut strategy_before_all_columns = TokenStream::default();
-    let mut strategies = vec![];
-    let mut strategy_after_all_columns = TokenStream::default();
+    let spacetimedb_call_prefix = quote! {
+        ctx
+            .db()
+            .#singular_table_name()
+    };
 
     let singular_table_name_as_string = singular_table_name.to_string();
+
+    let mut strategy_before_all = TokenStream::default();
+    let mut strategy_by_column = vec![];
+    let mut strategy_after_all = TokenStream::default();
 
     for column in &columns_by_on_delete_strategy {
         let column_name = &column.rust_field.name;
@@ -2179,96 +2379,20 @@ fn get_on_delete_strategy_implementation(
             .unwrap()
             .is_unique;
 
-        let spacetimedb_call_prefix = quote! {
-            ctx
-                .db()
-                .#singular_table_name()
-        };
-
         let row_finder = match is_unique_index {
             true => {
                 quote! {
-                    #spacetimedb_call_prefix.#column_name().find(referenced_row_primary_key_value)
+                    #spacetimedb_call_prefix.#column_name().find(primary_key_value_of_a_row_of_another_table_to_delete)
                 }
             }
             false => {
                 quote! {
-                    #spacetimedb_call_prefix.#column_name().filter(referenced_row_primary_key_value)
+                    #spacetimedb_call_prefix.#column_name().filter(primary_key_value_of_a_row_of_another_table_to_delete)
                 }
             }
         };
 
-        let referenced_table_one_function_name = get_referenced_table_function_name(
-            &DSLInternalReferencedByFunction::ExecuteOnDeleteStrategiesOfReferencingTablesAfterOneRowOfThisTableWasDeleted,
-            &singular_table_name
-        );
-
-        let referenced_table_multiple_function_name = get_referenced_table_function_name(
-            &DSLInternalReferencedByFunction::ExecuteOnDeleteStrategiesOfReferencingTablesAfterMultipleRowsOfThisTableWereDeleted,
-            &singular_table_name
-        );
-
-
-        let get_child_entries = match on_delete_strategy {
-            OnDeleteStrategy::Error | OnDeleteStrategy::SetZero | OnDeleteStrategy::Ignore => {
-                quote! {
-                    let child_entries = vec![];
-                }
-            }
-            OnDeleteStrategy::Delete => quote! {
-                // FIXME: I need better recursive functions for the result creation...
-
-                let mut child_entries = vec![];
-
-                 match spacetimedsl::internal::DSLInternals::#referenced_table_one_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::Error, #entry_or_entries) {
-                    Err(e) => {
-                        return Err(spacetimedsl::DeletionResult {
-                            table_name: #singular_table_name_as_string.into(),
-                            one_or_multiple: spacetimedsl::OneOrMultiple::#one_or_multiple_as_ident,
-                            entries: e.into_values().collect_vec(),
-                        });
-                    },
-                    Ok(e) => entries = e,
-                };
-
-                match spacetimedsl::internal::DSLInternals::#referenced_table_one_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::Delete, #entry_or_entries) {
-                    Err(e) => {
-                        return Err(spacetimedsl::DeletionResult {
-                            table_name: #singular_table_name_as_string.into(),
-                            one_or_multiple: spacetimedsl::OneOrMultiple::#one_or_multiple_as_ident,
-                            entries: e.into_values().collect_vec(),
-                        });
-                    },
-                    Ok(e) => entries = e,
-                };
-
-                /* // FIXME: If SetNone is implemented
-                match spacetimedsl::internal::DSLInternals::#referenced_table_one_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::SetNone, #entry_or_entries) {
-                    Err(e) => {
-                        return Err(spacetimedsl::DeletionResult {
-                            table_name: #singular_table_name_as_string.into(),
-                            one_or_multiple: spacetimedsl::OneOrMultiple::#one_or_multiple_as_ident,
-                            entries: e.into_values().collect_vec(),
-                        });
-                    },
-                    Ok(e) => entries = e,
-                };
-                */
-
-                match spacetimedsl::internal::DSLInternals::#referenced_table_one_function_name(self.ctx(), spacetimedsl::OnDeleteStrategy::SetZero, #entry_or_entries) {
-                    Err(e) => {
-                        return Err(spacetimedsl::DeletionResult {
-                            table_name: #singular_table_name_as_string.into(),
-                            one_or_multiple: spacetimedsl::OneOrMultiple::#one_or_multiple_as_ident,
-                            entries: e.into_values().collect_vec(),
-                        });
-                    },
-                    Ok(e) => entries = e,
-                };
-            },
-        };
-
-        let create_child_entry = quote! {
+        let create_entry = quote! {
             spacetimedsl::DeletionResultEntry {
                 table_name: #singular_table_name_as_string.into(),
                 column_name: #column_name_as_string.into(),
@@ -2278,180 +2402,287 @@ fn get_on_delete_strategy_implementation(
             }
         };
 
-        let add_row_as_child_entry_to_referenced_row;
+        let create_entry_and_add_it_to_entries;
 
         match one_or_multiple {
             OneOrMultiple::One => {
-                add_row_as_child_entry_to_referenced_row = quote! {
-                    #get_child_entries
-
-                    #entry_or_entries.1.child_entries.push(
-                        #create_child_entry
+                create_entry_and_add_it_to_entries = quote! {
+                    entries.push(
+                        #create_entry
                     );
                 };
             }
             OneOrMultiple::Multiple => {
-                add_row_as_child_entry_to_referenced_row = quote! {
-                    #get_child_entries
-
-                    #entry_or_entries.get_mut(&referenced_row_primary_key_value).unwrap().child_entries.push(
-                        #create_child_entry
-                    );
+                create_entry_and_add_it_to_entries = quote! {
+                    entries.get_mut(primary_key_value_of_a_row_of_another_table_to_delete).push(#create_entry);
                 };
             }
         };
-
-        let strategy;
 
         match on_delete_strategy {
             OnDeleteStrategy::Error => {
-                strategy_before_all_columns = quote! {
-                    let mut is_err = false;
-                };
+                strategy_by_column.push(strategy_by_row(
+                    false,
+                    is_unique_index,
+                    &row_finder,
+                    quote! {
+                        error = true;
 
-                let strategy_per_row = quote! {
-                    is_err = true;
-
-                    #add_row_as_child_entry_to_referenced_row
-                };
-
-                strategy_after_all_columns = quote! {
-                    match is_err {
-                        false => return Ok(#entry_or_entries),
-                        true => return Err(#entry_or_entries),
-                    }
-                };
-
-                strategy = match is_unique_index {
-                    true => quote! {
-                        let row = #row_finder;
-
-                        if row.is_some() {
-                            #strategy_per_row
-                        };
+                        let child_entries = vec![];
+                        let id = &row.id;
+                        #create_entry_and_add_it_to_entries
                     },
-                    false => quote! {
-                        let rows = #row_finder;
-
-                        for row in &rows {
-                            #strategy_per_row
-                        }
-                    },
-                };
+                ));
             }
             OnDeleteStrategy::Delete => {
-                strategy_before_all_columns = quote! {
-                    let mut primary_key_referencing_rows = std::collections::HashSet::new();
-                };
+                match has_referenced_bys {
+                    false => strategy_by_column.push(strategy_by_row(
+                        false,
+                        is_unique_index,
+                        &row_finder,
+                        quote! {
+                            let child_entries = vec![];
+                            let id = &row.id;
+                            #create_entry_and_add_it_to_entries
 
-                strategy_after_all_columns = quote! {
-                    for primary_key_referencing_row in primary_key_referencing_rows {
-                        #add_row_as_child_entry_to_referenced_row
+                            #spacetimedb_call_prefix
+                                .id()
+                                .delete(row.id);
+                        },
+                    )),
+                    true => {
+                        let error_strategy =
+                            get_referenced_table_function_call_for_strategy_implementation(
+                                singular_table_name,
+                                &singular_table_name_as_string,
+                                OnDeleteStrategy::Error,
+                            );
 
-                        // FIXME: On false Error
-                        #spacetimedb_call_prefix
-                            .#primary_key_column_name()
-                            .delete(primary_key_referencing_row.#primary_key_column_name);
-                    }
-                };
+                        let delete_strategy =
+                            get_referenced_table_function_call_for_strategy_implementation(
+                                singular_table_name,
+                                &singular_table_name_as_string,
+                                OnDeleteStrategy::Delete,
+                            );
 
-                strategy = match is_unique_index {
-                    true => quote! {
-                        match #row_finder {
-                            None => {},
-                            Some(row) => primary_key_referencing_rows.insert(row),
+                        /*
+                                               let set_none_strategy = get_referenced_table_function_call_for_strategy_implementation(
+                                                   singular_table_name,
+                                                   &singular_table_name_as_string,
+                                                   OnDeleteStrategy::SetNone,
+                                               );
+                        */
+
+                        let set_zero_strategy =
+                            get_referenced_table_function_call_for_strategy_implementation(
+                                singular_table_name,
+                                &singular_table_name_as_string,
+                                OnDeleteStrategy::SetZero,
+                            );
+
+                        let ignore_strategy =
+                            get_referenced_table_function_call_for_strategy_implementation(
+                                singular_table_name,
+                                &singular_table_name_as_string,
+                                OnDeleteStrategy::Ignore,
+                            );
+
+                        let strategy_for_each_row;
+
+                        strategy_before_all = quote! {
+                            let mut child_entries_by_primary_key_value_of_row_to_delete = std::collections::HashMap::new();
+                            let mut primary_key_values_of_rows_to_delete_by_primary_key_value_of_a_row_of_another_table_to_delete = std::collections::HashMap::new();
                         };
-                    },
-                    false => quote! {
-                        for row in #row_finder {
-                            primary_key_referencing_rows.insert(row);
-                        }
-                    },
+
+                        match one_or_multiple {
+                            OneOrMultiple::One => strategy_before_all.append_all(quote! {
+                                primary_key_values_of_rows_to_delete_by_primary_key_value_of_a_row_of_another_table_to_delete.insert(primary_key_value_of_a_row_of_another_table_to_delete, vec![]);
+                            }),
+                            OneOrMultiple::Multiple => strategy_before_all.append_all(quote! {
+                                for primary_key_value_of_a_row_of_another_table_to_delete in primary_key_values_of_rows_of_another_table_to_delete {
+                                    primary_key_values_of_rows_to_delete_by_primary_key_value_of_a_row_of_another_table_to_delete.insert(primary_key_value_of_a_row_of_another_table_to_delete, vec![]);
+                                }
+                            }),
+                        };
+
+                        strategy_for_each_row = quote! {
+                            if !child_entries_by_primary_key_value_of_row_to_delete.contains(&row.id) {
+                                primary_key_values_of_rows_to_delete_by_primary_key_value_of_a_row_of_another_table_to_delete.get_mut(primary_key_value_of_a_row_of_another_table_to_delete).push(&row.id);
+                                child_entries_by_primary_key_value_of_row_to_delete.insert(&row.id, vec![]);
+                            }
+                        };
+
+                        let create_entries_and_add_them_to_entries = quote! {
+                            for (primary_key_value_of_a_row_of_another_table_to_delete, primary_key_values_of_rows_to_delete) in primary_key_values_of_rows_to_delete_by_primary_key_value_of_a_row_of_another_table_to_delete {
+                                for id in primary_key_values_of_rows_to_delete {
+                                    let child_entries = child_entries_by_primary_key_value_of_row_to_delete.remove(id).unwrap();
+                                    #create_entry_and_add_it_to_entries
+                                }
+                            }
+                        };
+
+                        let special_error_handler = quote! {
+                            match error {
+                                false => {},
+                                true => {
+                                    #create_entries_and_add_them_to_entries
+                                    return Err(entries);
+                                }
+                            };
+                        };
+
+                        strategy_after_all = quote! {
+                            let primary_key_values_of_rows_to_delete = child_entries_by_primary_key_value_of_row_to_delete.keys().collect_vec();
+
+                            #error_strategy
+
+                            match error {
+                                false => {},
+                                true => {
+                                    #create_entries_and_add_them_to_entries
+                                    return Err(entries);
+                                }
+                            };
+
+                            // FIXME: Delete initial rows after success of error strategy
+
+                            #special_error_handler
+
+                            #delete_strategy
+
+                            #special_error_handler
+
+                            //TODO #set_none_strategy
+
+                            #special_error_handler
+
+                            #set_zero_strategy
+
+                            #special_error_handler
+
+                            #ignore_strategy
+
+                            #create_entries_and_add_them_to_entries
+                        };
+
+                        strategy_by_column.push(strategy_by_row(
+                            false,
+                            is_unique_index,
+                            &row_finder,
+                            strategy_for_each_row,
+                        ));
+                    }
                 };
             }
             OnDeleteStrategy::SetZero => {
-                let strategy_per_row = quote! {
-                    row.#column_name = 0;
+                strategy_by_column.push(strategy_by_row(
+                    true,
+                    is_unique_index,
+                    &row_finder,
+                    quote! {
+                        row.#column_name = 0;
 
-                    #add_row_as_child_entry_to_referenced_row
+                        // FIXME: try_update instead of update
+                        // FIXME: on error return Err(spacetimedsl::SpacetimeDSLError);
+                        #spacetimedb_call_prefix.id().update(row);
 
-                    // FIXME: try_update instead of update
-                    // FIXME: on error return Err(spacetimedsl::SpacetimeDSLError);
-                    #spacetimedb_call_prefix.#primary_key_column_name().update(row);
-                };
-
-                strategy = match is_unique_index {
-                    true => quote! {
-                        match #row_finder {
-                            None => {}
-                            Some(mut row) => { #strategy_per_row }
-                        };
+                        let child_entries = vec![];
+                        let id = &row.id;
+                        #create_entry_and_add_it_to_entries
                     },
-                    false => quote! {
-                        for mut row in #row_finder {
-                            #strategy_per_row
-                        }
-                    },
-                };
+                ));
             }
             OnDeleteStrategy::Ignore => {
-                let strategy_per_row = quote! {
-                    #add_row_as_child_entry_to_referenced_row
-                };
-
-                strategy = match is_unique_index {
-                    true => quote! {
-                        match #row_finder {
-                            None => {}
-                            Some(row) => { #strategy_per_row }
-                        };
+                strategy_by_column.push(strategy_by_row(
+                    false,
+                    is_unique_index,
+                    &row_finder,
+                    quote! {
+                        let child_entries = vec![];
+                        let id = &row.id;
+                        #create_entry_and_add_it_to_entries
                     },
-                    false => quote! {
-                        for row in #row_finder {
-                            #strategy_per_row
-                        }
-                    },
-                };
+                ));
             }
         };
-
-        strategies.push(strategy);
     }
 
-    let strategies = match one_or_multiple {
+    match one_or_multiple {
         OneOrMultiple::One => quote! {
-            let referenced_row_primary_key_value = entry.0;
+            #strategy_before_all
 
-            #(#strategies)*
+            #(#strategy_by_column)*
+
+            #strategy_after_all
         },
         OneOrMultiple::Multiple => quote! {
-            for referenced_row_primary_key_value in entries.keys() {
-                #(#strategies)*
+            #strategy_before_all
+
+            for primary_key_value_of_a_row_of_another_table_to_delete in primary_key_values_of_rows_of_another_table_to_delete {
+                #(#strategy_by_column)*
             }
+
+            #strategy_after_all
         },
-    };
-
-    quote! {
-        #on_delete_strategy => {
-            #strategy_before_all_columns
-
-            #strategies
-
-            #strategy_after_all_columns
-        }
     }
 }
 
-fn get_foreign_key_function_by_referenced_by_function(
-    dsl_internal_referenced_by_function: &DSLInternalReferencedByFunction,
-) -> DSLInternalForeignKeyFunction {
-    match *dsl_internal_referenced_by_function {
-        DSLInternalReferencedByFunction::ExecuteOnDeleteStrategiesOfReferencingTablesAfterOneRowOfThisTableWasDeleted => {
-            DSLInternalForeignKeyFunction::ExecuteOnDeleteStrategiesOfThisTableAfterOneRowOfTheReferencedTableWasDeleted
-        }
-        DSLInternalReferencedByFunction::ExecuteOnDeleteStrategiesOfReferencingTablesAfterMultipleRowsOfThisTableWereDeleted => {
-            DSLInternalForeignKeyFunction::ExecuteOnDeleteStrategiesOfThisTableAfterMultipleRowsOfTheReferencedTableWereDeleted
-        }
+fn strategy_by_row(
+    mut_row: bool,
+    is_unique_index: bool,
+    row_finder: &TokenStream,
+    strategy_by_row: TokenStream,
+) -> TokenStream {
+    let row_or_mut_row = match mut_row {
+        true => quote! {
+            mut row
+        },
+        false => quote! {
+            row
+        },
+    };
+
+    match is_unique_index {
+        true => quote! {
+            match #row_finder {
+                None => {}
+                Some(#row_or_mut_row) => {
+                    #strategy_by_row
+                }
+            };
+        },
+        false => quote! {
+            for #row_or_mut_row in #row_finder {
+                #strategy_by_row
+            }
+        },
+    }
+}
+
+fn get_referenced_table_function_call_for_strategy_implementation(
+    singular_table_name: &Ident,
+    singular_table_name_as_string: &String,
+    on_delete_strategy: OnDeleteStrategy,
+) -> TokenStream {
+    let referenced_table_function_name =
+        get_referenced_table_function_name(&OneOrMultiple::Multiple, &singular_table_name);
+
+    // std::collections::HashMap<&#primary_key_column_type, Vec<spacetimedsl::DeletionResultEntry>>
+    quote! {
+        match spacetimedsl::internal::DSLInternals::#referenced_table_function_name(self.ctx(), #on_delete_strategy, primary_key_values_of_rows_to_delete) {
+            Err(child_entries_by_primary_key_value_of_a_row_to_delete) => {
+                error = true;
+
+                for (primary_key_value_of_a_row_to_delete, child_entries) in child_entries_by_primary_key_value_of_a_row_to_delete {
+                    child_entries_by_primary_key_value_of_row_to_delete.get_mut(primary_key_value_of_a_row_to_delete).append(child_entries);
+                }
+            },
+            Ok(child_entries_by_primary_key_value_of_a_row_to_delete) => {
+                for (primary_key_value_of_a_row_to_delete, child_entries) in child_entries_by_primary_key_value_of_a_row_to_delete {
+                    child_entries_by_primary_key_value_of_row_to_delete.get_mut(primary_key_value_of_a_row_to_delete).append(child_entries);
+                }
+            }
+        };
     }
 }
 

--- a/derive-input/src/internal/dsl/wrapper.rs
+++ b/derive-input/src/internal/dsl/wrapper.rs
@@ -180,7 +180,7 @@ fn get_wrapper_impl(
 
         impl std::fmt::Display for #wrapper_struct_name {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                write!(f, format!("{} {{ id: {} }}", #wrapper_struct_name_as_str, self.value))
+                write!(f, "{} {{ id: {:?} }}", #wrapper_struct_name_as_str, self.value)
             }
         }
 

--- a/derive-input/src/internal/dsl/wrapper.rs
+++ b/derive-input/src/internal/dsl/wrapper.rs
@@ -143,6 +143,9 @@ fn get_wrapper_impl(
             #wrapped_type::default()
         }
     }
+
+    let wrapper_struct_name_as_str = wrapper_struct_name.to_string();
+
     quote! {
         #[derive(Clone, Debug, PartialEq, PartialOrd, spacetimedb::SpacetimeType)]
         pub struct #wrapper_struct_name {
@@ -175,6 +178,12 @@ fn get_wrapper_impl(
             }
         }
 
+        impl std::fmt::Display for #wrapper_struct_name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, format!("{} {{ id: {} }}", #wrapper_struct_name_as_str, self.value))
+            }
+        }
+
         impl spacetimedsl::Wrapper<#wrapped_type, #wrapper_struct_name> for #wrapper_struct_name {
             fn new(value: #wrapped_type) -> Self {
                 Self { value }
@@ -195,7 +204,10 @@ impl WrapperType {
     pub(in crate::internal) fn map_to_wrapped_type(value: &Wrap) -> Type {
         parse2(value.wrapped_type_name_or_path.to_token_stream()).expect(&format!(
             "Failed to parse {} as Ident in WrapperType::map_to_wrapped_type.",
-            &value.wrapped_type_name_or_path.to_token_stream().to_string()
+            &value
+                .wrapped_type_name_or_path
+                .to_token_stream()
+                .to_string()
         ))
     }
 

--- a/derive-input/src/internal/table.rs
+++ b/derive-input/src/internal/table.rs
@@ -26,12 +26,18 @@ pub(in crate::internal) fn try_parse(
         &spacetimedsl_table,
     )?;
 
+    let primary_key_column = internal_columns
+        .iter()
+        .find(|c| c.rust_field_name.to_string().eq(&"id"))
+        .expect("should have a primary key");
+
     let spacetimedsl_methods = SpacetimeDSLTableMethods::try_parse(
         &rust_struct,
         &spacetimedb_table,
         &spacetimedsl_table,
         &columns,
         &internal_columns,
+        primary_key_column,
     )?;
 
     Ok(Table {

--- a/derive-input/src/internal/table.rs
+++ b/derive-input/src/internal/table.rs
@@ -32,7 +32,6 @@ pub(in crate::internal) fn try_parse(
         &spacetimedb_table,
         &spacetimedsl_table,
         &columns,
-        &primary_key_column_name,
         &internal_columns,
     )?;
 

--- a/derive-input/src/internal/table.rs
+++ b/derive-input/src/internal/table.rs
@@ -19,13 +19,12 @@ pub(in crate::internal) fn try_parse(
     let (spacetimedb_table, spacetimedsl_table) =
         SpacetimeDSLTable::try_parse(args, column_args, spacetimedb_table)?;
 
-    let (spacetimedb_table, columns, internal_columns, primary_key_column_name) =
-        super::column::try_parse(
-            &column_args,
-            &rust_struct,
-            spacetimedb_table,
-            &spacetimedsl_table,
-        )?;
+    let (spacetimedb_table, columns, internal_columns) = super::column::try_parse(
+        &column_args,
+        &rust_struct,
+        spacetimedb_table,
+        &spacetimedsl_table,
+    )?;
 
     let spacetimedsl_methods = SpacetimeDSLTableMethods::try_parse(
         &rust_struct,

--- a/derive/src/output.rs
+++ b/derive/src/output.rs
@@ -53,15 +53,11 @@ pub(crate) fn output(input: &Table) -> syn::Result<TokenStream> {
     }
 
     for execute_on_delete_strategies_of_this_table_after_one_row_of_the_referenced_table_was_deleted in &input.spacetimedsl_methods.execute_on_delete_strategies_of_this_table_after_one_row_of_the_referenced_table_was_deleted {
-        dsl_methods.push(build_internal(
-            execute_on_delete_strategies_of_this_table_after_one_row_of_the_referenced_table_was_deleted
-        )?);
+        dsl_methods.push(build_internal(execute_on_delete_strategies_of_this_table_after_one_row_of_the_referenced_table_was_deleted)?);
     }
 
     for execute_on_delete_strategies_of_this_table_after_multiple_rows_of_the_referenced_table_were_deleted in &input.spacetimedsl_methods.execute_on_delete_strategies_of_this_table_after_multiple_rows_of_the_referenced_table_were_deleted {
-        dsl_methods.push(build_internal(
-            execute_on_delete_strategies_of_this_table_after_multiple_rows_of_the_referenced_table_were_deleted
-        )?);
+        dsl_methods.push(build_internal(execute_on_delete_strategies_of_this_table_after_multiple_rows_of_the_referenced_table_were_deleted)?);
     }
 
     for multi_column_index in &input.spacetimedsl_methods.multi_column_indices {
@@ -235,7 +231,7 @@ pub fn build_internal(method: &SpacetimeDSLMethod) -> syn::Result<TokenStream> {
         #[doc=#doc_comment]
         pub trait #trait_name {
             #[doc=#doc_comment]
-            fn #method_name(
+            fn #method_name<'a>(
                 #(#method_args),*
             ) -> #return_type {
                 use spacetimedsl::Wrapper;

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -328,7 +328,6 @@ pub mod test {
             test::{
                 CreateShipObjectRow, CreateTestRow, DeleteTestRowsByBtreeIndex,
                 DeleteTestRowsByWrappedIndex, GetTestRowsByBtreeIndex, GetTestRowsByWrappedIndex,
-                Test,
             },
         },
         entity::{
@@ -341,25 +340,20 @@ pub mod test {
         },
     };
     use log::info;
-    use spacetimedb::{ReducerContext, TimeDuration, TryInsertError, reducer};
+    use spacetimedb::{ReducerContext, TimeDuration, reducer};
     use spacetimedsl::{Wrapper, dsl};
 
     #[reducer]
     fn tester(ctx: &ReducerContext) -> Result<(), String> {
         let dsl = dsl(ctx);
 
-        let result: Result<
-            crate::entity::Entity,
-            TryInsertError<crate::entity::entity__TableHandle>,
-        >;
-
         let mut player;
         match dsl.create_entity() {
             Ok(entity) => {
                 player = entity;
             }
-            Err(_) => {
-                return Err("Should be able to create an Entity!".to_string());
+            Err(error) => {
+                return Err(format!("Should be able to create an Entity! Got:\n{error}"));
             }
         };
 
@@ -372,11 +366,13 @@ pub mod test {
         }
 
         match dsl.get_entity_by_id(&player) {
-            Some(entity) => {
+            Ok(entity) => {
                 player = entity;
             }
-            None => {
-                return Err("Should be able to get an Entity by it's ID!".to_string());
+            Err(error) => {
+                return Err(format!(
+                    "Should be able to get an Entity by it's ID! Got:\n{error}"
+                ));
             }
         };
 
@@ -385,17 +381,19 @@ pub mod test {
             Ok(entity) => {
                 player2 = entity;
             }
-            Err(_) => {
-                return Err("Should be able to create an Entity!".to_string());
+            Err(error) => {
+                return Err(format!("Should be able to create an Entity! Got:\n{error}"));
             }
         };
 
-        if dsl.create_identifier(&player, "cool").is_err() {
-            return Err(format!(
-                "{:?}: Should be able to add an newly created Identifier!",
-                player
-            ));
-        }
+        match dsl.create_identifier(&player, "cool") {
+            Ok(_) => {}
+            Err(error) => {
+                return Err(format!(
+                    "{player:?}: Should be able to add an newly created Identifier! Got:\n{error}"
+                ));
+            }
+        };
 
         if dsl.count_of_all_identifiers().ne(&1) {
             return Err("Count of identifiers should be 1!".to_string());
@@ -421,29 +419,43 @@ pub mod test {
             return Err("Count of entity relationships should be 3!".to_string());
         }
 
-        if dsl.delete_entity_by_id(&player3).is_err() {
-            return Err("Should be able to delete 'player3' because it's only a child in entity relationships!".to_string());
-        }
+        match dsl.delete_entity_by_id(&player3) {
+            Ok(_) => {}
+            Err(error) => {
+                return Err(format!(
+                    "Should be able to delete 'player3' because it's only a child in entity relationships! Got:\n{error}"
+                ));
+            }
+        };
 
         if dsl.count_of_all_entity_relationships().ne(&1) {
             return Err("Count of entity relationships should be 1 because 2 should be deleted through the foreign key / referenced by feature!".to_string());
         }
 
-        if dsl.delete_entity_by_id(&player2).is_err() {
-            return Err("Should be able to delete 'player2' because it's only a child in entity relationships!".to_string());
-        }
+        match dsl.delete_entity_by_id(&player2) {
+            Ok(_) => {}
+            Err(error) => {
+                return Err(format!(
+                    "Should be able to delete 'player2' because it's only a child in entity relationships! Got:\n{error}"
+                ));
+            }
+        };
 
         if dsl.count_of_all_entity_relationships().ne(&0) {
             return Err(
                 "Count of entity relationships should be 0 because the last one should be deleted through the foreign key / referenced by feature!".to_string(),
             );
         }
+        match dsl.delete_entity_by_id(&player) {
+            Ok(_) => {}
+            Err(error) => {
+                return Err(format!(
+                    "Should be able to delete 'player' because it's not a parent anymore in a entity relationship! Got:\n{error}"
+                ));
+            }
+        };
 
-        if dsl.delete_entity_by_id(&player).is_err() {
-            return Err("Should be able to delete 'player' because it's not a parent anymore in a entity relationship!".to_string());
-        }
-
-        if dsl.get_entity_by_id(&player).is_some() {
+        if dsl.get_entity_by_id(&player).is_ok() {
             return Err(
                 "Shouldn't be able to get an Entity by an ID which doesn't exist!".to_string(),
             );
@@ -457,8 +469,8 @@ pub mod test {
             Ok(entity) => {
                 player = entity;
             }
-            Err(_) => {
-                return Err("Should be able to create an Entity!".to_string());
+            Err(error) => {
+                return Err(format!("Should be able to create an Entity! Got:\n{error}"));
             }
         };
 
@@ -473,9 +485,10 @@ pub mod test {
             return Err("Count of entity relationships 2 should be 3!".to_string());
         }
 
-        if dsl.delete_entity_by_id(&player2).is_err() {
-            return Err("Should be able to delete 'player'".to_string());
-        }
+        match dsl.delete_entity_by_id(&player2) {
+            Ok(_) => {}
+            Err(error) => return Err(format!("Should be able to delete 'player'! Got:\n{error}")),
+        };
 
         if dsl.count_of_all_entity_relationships2().ne(&1) {
             return Err("Count of entity relationships should be 1 because 2 should be deleted through the foreign key / referenced by feature!".to_string());
@@ -484,10 +497,18 @@ pub mod test {
         let er4_1 = dsl.create_entity_relationship4(EntityRelationship4Id::new(0))?;
         let mut er4_2 = dsl.create_entity_relationship4(&er4_1)?;
 
-        let res = dsl.delete_entity_relationship4_by_id(&er4_1);
-
-        if res.is_err() || res.is_ok_and(|r| r.eq(&false)) {
-            return Err("Should be able to delete 'er4_1'".to_string());
+        match dsl.delete_entity_relationship4_by_id(&er4_1) {
+            Ok(success) => {
+                if success.entries[0]
+                    .row_value
+                    .ne(&er4_1.get_id().to_string().into())
+                {
+                    return Err(format!("Should be able to delete 'er4_1'! Got: {} and {}\n{success}", success.entries[0].row_value, er4_1.get_id()));
+                }
+            }
+            Err(error) => {
+                return Err(format!("Should be able to delete 'er4_1'! Got:\n{error}"));
+            }
         }
 
         if er4_2.get_parent_entity_relationship4_id().ne(&dsl
@@ -516,9 +537,9 @@ pub mod test {
             Ok(identifier) => {
                 player_identifier = identifier;
             }
-            Err(_) => {
+            Err(error) => {
                 return Err(format!(
-                    "{:?}: Should be able to add an newly created Identifier!",
+                    "{:?}: Should be able to add an newly created Identifier! Got:\n{error}",
                     player
                 ));
             }
@@ -558,11 +579,13 @@ pub mod test {
         };
 
         match dsl.get_identifier_by_value("PLAYER") {
-            Some(identifier) => {
+            Ok(identifier) => {
                 player_identifier = identifier;
             }
-            None => {
-                return Err("Should be able to get an Identifier by it's value!".to_string());
+            Err(error) => {
+                return Err(format!(
+                    "Should be able to get an Identifier by it's value! Got:\n{error}"
+                ));
             }
         }
 
@@ -599,7 +622,7 @@ pub mod test {
         let player_reflection = player;
 
         match dsl.get_identifier_by_entity_id(&player_reflection) {
-            Some(identifier) => {
+            Ok(identifier) => {
                 if identifier
                     .get_value()
                     .ne(player_reflection_identifier.get_value())
@@ -611,8 +634,10 @@ pub mod test {
                     ));
                 }
             }
-            None => {
-                return Err("Should be able to get an Identifier by it's Entity!".to_string());
+            Err(error) => {
+                return Err(format!(
+                    "Should be able to get an Identifier by it's Entity! Got:\n{error}"
+                ));
             }
         }
         let player_reflection_position_id;
@@ -631,8 +656,8 @@ pub mod test {
             Ok(entity) => {
                 player = entity;
             }
-            Err(_) => {
-                return Err("Should be able to create an Entity!".to_string());
+            Err(error) => {
+                return Err(format!("Should be able to create an Entity! Got:\n{error}"));
             }
         };
 
@@ -759,7 +784,7 @@ pub mod test {
             return Err("The count of unique Positions should equal!".to_string());
         }
 
-        let world1 = handle_test_result(dsl.create_test(
+        let world1 = dsl.create_test(
             None,
             &player,
             &player,
@@ -772,9 +797,9 @@ pub mod test {
             Some("wrapped_string_option".to_string()),
             0,
             spacetimedb::ScheduleAt::Time(ctx.timestamp),
-        ))?;
+        )?;
 
-        let mut world2 = handle_test_result(dsl.create_test(
+        let mut world2 = dsl.create_test(
             &player,
             player_reflection.get_id(),
             player.get_id(),
@@ -787,7 +812,8 @@ pub mod test {
             Some("wrapped_string_option".to_string()),
             1,
             spacetimedb::ScheduleAt::Time(ctx.timestamp),
-        ))?;
+        )?;
+
         let _: Option<EntityId> = world1.get_wrapped_option();
         world2.set_wrapped_option(None);
         world2.set_wrapped_option(&player);
@@ -815,9 +841,15 @@ pub mod test {
         let _ = dsl.delete_tests_by_btree_index(world2.get_btree_index());
         //let _ = dsl.delete_tests_by_btree_index(world2.get_btree_index()..);
 
-        if dsl.delete_entity_by_id(&player_reflection).is_err() {
-            return Err("Should be able to delete the player_reflection Entity!".to_string());
+        match dsl.delete_entity_by_id(&player_reflection) {
+            Ok(_) => {}
+            Err(error) => {
+                return Err(format!(
+                    "Should be able to delete the player_reflection Entity! Got:\n{error}"
+                ));
+            }
         }
+
         if dsl.count_of_all_identifiers().ne(&0) {
             return Err("The count of Identifiers should be 0 because the player_reflection Entity was deleted and the foreign key has a Delete strategy!".to_string());
         }
@@ -835,8 +867,10 @@ pub mod test {
 
         // TODO: TryDeleteError
         match dsl.delete_entity_by_id(&player) {
-            Ok(_) => {
-                return Err("The deletion of the entity player shouldn't have worked because ship_object.entity_id has a foreign key on the entity id with Error strategy".to_string());
+            Ok(success) => {
+                return Err(format!(
+                    "The deletion of the entity player shouldn't have worked because ship_object.entity_id has a foreign key on the entity id with Error strategy Got: {success}",
+                ));
             }
             Err(_) => {}
         };
@@ -847,25 +881,5 @@ pub mod test {
         info!("Test executed successfully!");
 
         Ok(())
-    }
-
-    fn handle_test_result(
-        result: Result<
-            Test,
-            spacetimedb::TryInsertError<crate::component::test::test__TableHandle>,
-        >,
-    ) -> Result<Test, Box<str>> {
-        match result {
-            Ok(w) => {
-                return Ok(w);
-            }
-            Err(e) => {
-                return Err(format!(
-                    "Should have been able to create a test. Got: {}",
-                    e.to_string()
-                )
-                .into());
-            }
-        }
     }
 }

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -76,7 +76,23 @@ pub mod entity {
         #[index(btree)]
         #[wrapped(name = EntityRelationship3Id)]
         #[foreign_key(path = crate::entity, table = entity_relationship3, on_delete = SetZero)]
-        parent_entity_id: u128,
+        parent_entity_relationship3_id: u128,
+    }
+
+    #[dsl(plural_name = entity_relationships4)]
+    #[table(name = entity_relationship4, public)]
+    pub struct EntityRelationship4 {
+        /// The unique ID of the Entity Relationship3.
+        #[primary_key]
+        #[auto_inc]
+        #[wrap]
+        #[referenced_by(path = crate::entity, table = entity_relationship4)]
+        id: u128,
+
+        #[index(btree)]
+        #[wrapped(name = EntityRelationship4Id)]
+        #[foreign_key(path = crate::entity, table = entity_relationship4, on_delete = Ignore)]
+        pub parent_entity_relationship4_id: u128,
     }
 }
 
@@ -110,7 +126,7 @@ pub mod component {
 
             modified_at: Timestamp,
         }
-        
+
         #[dsl(plural_name = identifier_references)]
         #[table(name = identifier_reference, public)]
         pub struct IdentifierReference {
@@ -317,17 +333,25 @@ pub mod test {
         },
         entity::{
             CountOfAllEntityRelationship2Rows, CountOfAllEntityRelationshipRows,
-            CreateEntityRelationship2Row, CreateEntityRelationshipRow, CreateEntityRow,
-            DeleteEntityRowById, EntityId, GetEntityRowOptionById,
+            CreateEntityRelationship2Row, CreateEntityRelationship4Row,
+            CreateEntityRelationshipRow, CreateEntityRow, DeleteEntityRelationship4RowById,
+            DeleteEntityRowById, EntityId, EntityRelationship4Id,
+            GetEntityRelationship4RowOptionById, GetEntityRowOptionById,
+            UpdateEntityRelationship4RowById,
         },
     };
     use log::info;
-    use spacetimedb::{ReducerContext, TimeDuration, reducer};
+    use spacetimedb::{ReducerContext, TimeDuration, TryInsertError, reducer};
     use spacetimedsl::{Wrapper, dsl};
 
     #[reducer]
     fn tester(ctx: &ReducerContext) -> Result<(), String> {
         let dsl = dsl(ctx);
+
+        let result: Result<
+            crate::entity::Entity,
+            TryInsertError<crate::entity::entity__TableHandle>,
+        >;
 
         let mut player;
         match dsl.create_entity() {
@@ -455,6 +479,36 @@ pub mod test {
 
         if dsl.count_of_all_entity_relationships2().ne(&1) {
             return Err("Count of entity relationships should be 1 because 2 should be deleted through the foreign key / referenced by feature!".to_string());
+        }
+
+        let er4_1 = dsl.create_entity_relationship4(EntityRelationship4Id::new(0))?;
+        let mut er4_2 = dsl.create_entity_relationship4(&er4_1)?;
+
+        let res = dsl.delete_entity_relationship4_by_id(&er4_1);
+
+        if res.is_err() || res.is_ok_and(|r| r.eq(&false)) {
+            return Err("Should be able to delete 'er4_1'".to_string());
+        }
+
+        if er4_2.get_parent_entity_relationship4_id().ne(&dsl
+            .get_entity_relationship4_by_id(&er4_2)
+            .expect("shouldn't be deleted")
+            .get_parent_entity_relationship4_id())
+        {
+            return Err(
+                "`parent_entity_relationship4_id` of `er4_2` shouldn't have changed.".to_string(),
+            );
+        }
+
+        er4_2.set_parent_entity_relationship4_id(EntityRelationship4Id::new(0));
+        er4_2 = dsl.update_entity_relationship4_by_id(er4_2)?;
+        er4_2.set_parent_entity_relationship4_id(&er4_1);
+        if dsl.update_entity_relationship4_by_id(er4_2).is_ok() {
+            return Err("Shouldn't be able to set `parent_entity_relationship4_id` of `er4_2` to id of previously deleted `er4_1`".to_string());
+        }
+
+        if dsl.create_entity_relationship4(&er4_1).is_ok() {
+            return Err("Shouldn't be able to create a `entity_relationship4` with `er4_1` as `parent_entity_relationship4_id`".to_string());
         }
 
         let mut player_identifier;
@@ -787,6 +841,7 @@ pub mod test {
             Err(_) => {}
         };
 
+        // FIXME: Add test where two foreign keys match the same primary key - is it tried to delete the same row two times and therefore it fails?
         // TODO: Add test for SetNone strategy if it's implemented
 
         info!("Test executed successfully!");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 pub use itertools;
 use spacetimedb::ReducerContext;
 pub use spacetimedsl_derive::{SpacetimeDSL, dsl};
-use std::collections::HashMap;
 use std::{
     error::Error,
     fmt::{self, Display},
@@ -88,135 +87,177 @@ impl Display for OnDeleteStrategy {
 }
 
 #[derive(Debug)]
-pub struct DeletionResult {
-    pub table_name: Box<str>,
-    pub primary_key_values: Vec<PrimaryKeyValue>,
-    pub on_delete_strategy_executions: Option<OnDeleteStrategyExecutions>,
+pub enum SpacetimeDSLError<'a> {
+    NotFoundError {
+        table_name: Box<str>,
+        column_names_and_row_values: Box<str>,
+    },
+    UniqueConstraintViolation {
+        table_name: Box<str>,
+        create_or_update: CreateOrUpdate,
+        error_from: ErrorFrom,
+        column_names_and_row_values: Box<str>,
+    },
+    AutoIncOverflow {
+        table_name: Box<str>,
+    },
+    ReferenceIntegrityViolation(DeletionResult<'a>),
 }
 
-impl DeletionResult {
-    pub fn is_one_deletion(&self) -> bool {
-        self.primary_key_values.len().eq(&1)
+impl<'a> Display for SpacetimeDSLError<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut message: String = String::new();
+
+        let dig_spacetimedb = "Unfortunately SpacetimeDB doesn't provide more information";
+
+        message.push_str(&match self {
+            SpacetimeDSLError::NotFoundError {
+                table_name,
+                column_names_and_row_values
+            } => format!("Not Found Error while trying to find a row in the `{table_name}` table with {column_names_and_row_values}!"),
+            SpacetimeDSLError::UniqueConstraintViolation {
+                table_name,
+                create_or_update,
+                error_from,
+                column_names_and_row_values,
+            } => {
+                let create_or_update = match create_or_update {
+                    CreateOrUpdate::Create => "create",
+                    CreateOrUpdate::Update => "update",
+                };
+
+                let column_names_and_row_values = match error_from {
+                    ErrorFrom::SpacetimeDB => format!("! {dig_spacetimedb}, so here are all columns and their values: {column_names_and_row_values}."),
+                    ErrorFrom::SpacetimeDSL => format!(" because of {column_names_and_row_values}!"),
+                };
+
+                format!("Unique Constraint Violation Error while trying to {create_or_update} a row in the `{table_name}` table{column_names_and_row_values}")
+            }
+            SpacetimeDSLError::AutoIncOverflow { table_name } => {
+                format!("Auto Inc Overflow Error on `{table_name}` table! {dig_spacetimedb}.")
+            }
+            SpacetimeDSLError::ReferenceIntegrityViolation(error) => {
+                format!("Reference Integrity Violation Error: {}", error.to_error_string())
+            }
+        });
+
+        write!(f, "{}", message)
     }
 }
 
-pub type OnDeleteStrategyExecutions =
-    HashMap<PrimaryKeyValue, HashMap<OnDeleteStrategy, Vec<(ColumnName, DeletionResult)>>>;
+impl<'a> Error for SpacetimeDSLError<'a> {}
 
-pub type ReferenceIntegrityViolationError = DeletionResult;
+#[derive(Debug)]
+pub enum CreateOrUpdate {
+    Create,
+    Update,
+}
 
-type ColumnName = Box<str>;
-type PrimaryKeyValue = Box<str>;
+#[derive(Debug)]
+pub enum ErrorFrom {
+    SpacetimeDB,
+    SpacetimeDSL,
+}
+
+#[derive(Debug)]
+pub enum OneOrMultiple {
+    One,
+    Multiple,
+}
+
+#[derive(Debug)]
+pub struct DeletionResult<'a> {
+    pub table_name: &'a str,
+    pub one_or_multiple: OneOrMultiple,
+    pub table_names: Vec<Box<str>>,
+    pub column_names: Vec<Box<str>>,
+    pub entries: Vec<DeletionResultEntry<'a>>,
+}
+
+#[derive(Debug)]
+pub struct DeletionResultEntry<'a> {
+    pub table_name: &'a str,
+    pub column_name: &'a str,
+    pub strategy: OnDeleteStrategy,
+    pub row_value: Box<str>,
+    pub child_entries: Vec<DeletionResultEntry<'a>>,
+}
+
+impl<'a> DeletionResultEntry<'a> {
+    pub fn to_csv(
+        &self,
+        mut entry_id: u128,
+        mut parent_entry_id: u128,
+        mut message: String,
+    ) -> (u128, String) {
+        entry_id += 1;
+
+        let table_name = self.table_name;
+        let column_name = self.column_name;
+        let strategy = &self.strategy;
+        let row_value = &self.row_value;
+
+        message.push_str(&format!(
+            "{entry_id}, {parent_entry_id}, {table_name}, {column_name}, {strategy}, {row_value}\n"
+        ));
+
+        parent_entry_id = entry_id;
+
+        for child_entry in &self.child_entries {
+            (entry_id, message) = child_entry.to_csv(entry_id, parent_entry_id, message);
+        }
+
+        (entry_id, message)
+    }
+}
+
+impl<'a> fmt::Display for DeletionResult<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut message = String::new();
+
+        message
+            .push_str("entry_id, parent_entry_id, table_name, column_name, strategy, row_value,\n");
+
+        let mut entry_id: u128 = 0;
+
+        for entry in &self.entries {
+            (entry_id, message) = entry.to_csv(entry_id, 0, message);
+        }
+
+        write!(f, "{}", message)
+    }
+}
+
+impl DeletionResult<'_> {
+    pub fn to_error_string(&self) -> String {
+        let mut message: String = String::new();
+
+        message.push_str("While deleting ");
+
+        match self.one_or_multiple {
+            OneOrMultiple::One => message.push_str("a row "),
+            OneOrMultiple::Multiple => message.push_str("rows "),
+        }
+
+        message.push_str(&format!(
+            "in the `{}` table, the following reference integrity violations occurred:\n\n",
+            &self.table_name
+        ));
+
+        message
+            .push_str("entry_id, parent_entry_id, table_name, column_name, strategy, row_value,\n");
+
+        let mut entry_id: u128 = 0;
+
+        for entry in &self.entries {
+            (entry_id, message) = entry.to_csv(entry_id, 0, message);
+        }
+
+        message
+    }
+}
 
 #[doc(hidden)]
 pub mod internal {
-    use crate::{DeletionResult, OnDeleteStrategy, ReferenceIntegrityViolationError};
-    use core::fmt;
-
     pub struct DSLInternals;
-
-    impl fmt::Display for ReferenceIntegrityViolationError {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            let mut message: String = String::new();
-
-            message.push_str("Reference Integrity Violation Error: While deleting ");
-
-            let only_one_deletion = self.is_one_deletion();
-            if only_one_deletion {
-                message.push_str("a row ");
-            } else {
-                message.push_str("rows ");
-            }
-
-            message.push_str(&format!(
-                "in the `{}` table, the following reference integrity violations occurred:\n\n",
-                &self.table_name
-            ));
-
-            // TODO: Create a data structure like this and use this as the DeletionResult instead of the current one
-            message.push_str("error_id,table,pk_value,parent_error_id,reason,trace\n");
-
-            let mut error_id: u128 = 1;
-            let mut parent_error_id: Box<str> = "".into();
-
-            for (primary_key_value, results_by_strategy) in
-                self.on_delete_strategy_executions.as_ref().expect("should exist")
-            {
-                message.push_str(&format!(
-                    "{},{},{},{},,\n",
-                    &error_id, &self.table_name, &primary_key_value, &parent_error_id
-                ));
-
-                parent_error_id = format!("{error_id}").into();
-                let trace = format!("{error_id}").into();
-
-                for (foreign_key_column_name, result) in
-                    results_by_strategy.get(&OnDeleteStrategy::Error).expect("should exist")
-                {
-                    (message, error_id) = process_each_reference_integrity_violation(
-                        message,
-                        error_id,
-                        &parent_error_id,
-                        foreign_key_column_name,
-                        primary_key_value,
-                        &trace,
-                        result,
-                    )
-                }
-            }
-
-            write!(f, "{}", message)
-        }
-    }
-
-    fn process_each_reference_integrity_violation(
-        mut message: String,
-        mut error_id: u128,
-        parent_error_id: &Box<str>,
-        foreign_key_column_name: &Box<str>,
-        foreign_key_column_value: &Box<str>,
-        trace: &Box<str>,
-        result: &DeletionResult,
-    ) -> (String, u128) {
-        for primary_key_value in &result.primary_key_values {
-            error_id += 1;
-
-            let trace: Box<str> = format!("{trace}<-{error_id}").into();
-            message.push_str(&format!(
-                "{},{},{},{},{} == {},{}{}\n",
-                &error_id,
-                &result.table_name,
-                &primary_key_value,
-                &parent_error_id,
-                foreign_key_column_name,
-                foreign_key_column_value,
-                trace,
-                &error_id
-            ));
-
-            if result.on_delete_strategy_executions.is_some() {
-                for (foreign_key_column_name, result) in result
-                    .on_delete_strategy_executions
-                    .as_ref()
-                    .expect("should exist")
-                    .get(primary_key_value)
-                    .expect("should exist")
-                    .get(&OnDeleteStrategy::Error)
-                    .expect("should exist")
-                {
-                    (message, error_id) = process_each_reference_integrity_violation(
-                        message,
-                        error_id,
-                        &parent_error_id,
-                        foreign_key_column_name,
-                        &primary_key_value,
-                        &trace,
-                        result,
-                    )
-                }
-            }
-        }
-
-        (message, error_id)
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,8 +95,9 @@ pub enum SpacetimeDSLError {
     },
     UniqueConstraintViolation {
         table_name: Box<str>,
-        create_or_update: CreateOrUpdate,
+        action: Action,
         error_from: ErrorFrom,
+        one_or_multiple: OneOrMultiple,
         column_names_and_row_values: Box<str>,
     },
     AutoIncOverflow {
@@ -109,7 +110,7 @@ pub enum SpacetimeDSLError {
 pub enum ReferenceIntegrityViolationError {
     OnCreateOrUpdate {
         table_name: Box<str>,
-        create_or_update: CreateOrUpdate,
+        create_or_update: Action,
         column_names_and_row_values: Box<str>,
     },
     OnDelete(DeletionResult),
@@ -129,21 +130,23 @@ impl Display for SpacetimeDSLError {
             } => format!("Not Found Error while trying to find a row in the `{table_name}` table with `{column_names_and_row_values}`!"),
             SpacetimeDSLError::UniqueConstraintViolation {
                 table_name,
-                create_or_update,
+                action,
                 error_from,
+                one_or_multiple,
                 column_names_and_row_values,
             } => {
-                let create_or_update = match create_or_update {
-                    CreateOrUpdate::Create => "create",
-                    CreateOrUpdate::Update => "update",
-                };
-
                 let column_names_and_row_values = match error_from {
                     ErrorFrom::SpacetimeDB => format!("! {dig_spacetimedb}, so here are all columns and their values: `{column_names_and_row_values}`."),
-                    ErrorFrom::SpacetimeDSL => format!(" because of `{column_names_and_row_values}`!"),
+                    ErrorFrom::SpacetimeDSL => {
+                        let one_or_multiple = match one_or_multiple {
+                            OneOrMultiple::One => "",
+                            OneOrMultiple::Multiple => " There can be two reasons for this: You are inserting or updating somewhere using spacetimedb::ReducerContext instead of spacetimedsl::DSL or the unique multi-column index feature of SpacetimeDSL is broken.",
+                        };
+                        format!(" because of `{column_names_and_row_values}`!{one_or_multiple}")
+                    },
                 };
 
-                format!("Unique Constraint Violation Error while trying to {create_or_update} a row in the `{table_name}` table{column_names_and_row_values}")
+                format!("Unique Constraint Violation Error while trying to {action} a row in the `{table_name}` table{column_names_and_row_values}")
             }
             SpacetimeDSLError::AutoIncOverflow { table_name } => {
                 format!("Auto Inc Overflow Error on `{table_name}` table! {dig_spacetimedb}.")
@@ -156,8 +159,8 @@ impl Display for SpacetimeDSLError {
                         column_names_and_row_values
                     } => {
                         let create_or_update = match create_or_update {
-                            CreateOrUpdate::Create => "create",
-                            CreateOrUpdate::Update => "update",
+                            Action::Get | Action::Delete => panic!("Reference Integrity Violation Error On Create Or Update only allowed while creating or updating a row."),
+                            action => action.to_string()
                         };
 
                         format!("Reference Integrity Violation Error while trying to {create_or_update} a row in the `{table_name}` table because of `{column_names_and_row_values}`!")
@@ -181,9 +184,22 @@ impl Display for SpacetimeDSLError {
 impl Error for SpacetimeDSLError {}
 
 #[derive(Debug)]
-pub enum CreateOrUpdate {
+pub enum Action {
     Create,
+    Get,
     Update,
+    Delete,
+}
+
+impl Display for Action {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Action::Create => write!(f, "create"),
+            Action::Get => write!(f, "get"),
+            Action::Update => write!(f, "update"),
+            Action::Delete => write!(f, "delete"),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ impl Display for OnDeleteStrategy {
 }
 
 #[derive(Debug)]
-pub enum SpacetimeDSLError<'a> {
+pub enum SpacetimeDSLError {
     NotFoundError {
         table_name: Box<str>,
         column_names_and_row_values: Box<str>,
@@ -101,10 +101,10 @@ pub enum SpacetimeDSLError<'a> {
     AutoIncOverflow {
         table_name: Box<str>,
     },
-    ReferenceIntegrityViolation(DeletionResult<'a>),
+    ReferenceIntegrityViolation(DeletionResult),
 }
 
-impl<'a> Display for SpacetimeDSLError<'a> {
+impl Display for SpacetimeDSLError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut message: String = String::new();
 
@@ -145,7 +145,7 @@ impl<'a> Display for SpacetimeDSLError<'a> {
     }
 }
 
-impl<'a> Error for SpacetimeDSLError<'a> {}
+impl Error for SpacetimeDSLError {}
 
 #[derive(Debug)]
 pub enum CreateOrUpdate {
@@ -166,24 +166,22 @@ pub enum OneOrMultiple {
 }
 
 #[derive(Debug)]
-pub struct DeletionResult<'a> {
-    pub table_name: &'a str,
+pub struct DeletionResult {
+    pub table_name: Box<str>,
     pub one_or_multiple: OneOrMultiple,
-    pub table_names: Vec<Box<str>>,
-    pub column_names: Vec<Box<str>>,
-    pub entries: Vec<DeletionResultEntry<'a>>,
+    pub entries: Vec<DeletionResultEntry>,
 }
 
 #[derive(Debug)]
-pub struct DeletionResultEntry<'a> {
-    pub table_name: &'a str,
-    pub column_name: &'a str,
+pub struct DeletionResultEntry {
+    pub table_name: Box<str>,
+    pub column_name: Box<str>,
     pub strategy: OnDeleteStrategy,
     pub row_value: Box<str>,
-    pub child_entries: Vec<DeletionResultEntry<'a>>,
+    pub child_entries: Vec<DeletionResultEntry>,
 }
 
-impl<'a> DeletionResultEntry<'a> {
+impl DeletionResultEntry {
     pub fn to_csv(
         &self,
         mut entry_id: u128,
@@ -192,8 +190,8 @@ impl<'a> DeletionResultEntry<'a> {
     ) -> (u128, String) {
         entry_id += 1;
 
-        let table_name = self.table_name;
-        let column_name = self.column_name;
+        let table_name = &self.table_name;
+        let column_name = &self.column_name;
         let strategy = &self.strategy;
         let row_value = &self.row_value;
 
@@ -211,7 +209,7 @@ impl<'a> DeletionResultEntry<'a> {
     }
 }
 
-impl<'a> fmt::Display for DeletionResult<'a> {
+impl fmt::Display for DeletionResult {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut message = String::new();
 
@@ -228,7 +226,7 @@ impl<'a> fmt::Display for DeletionResult<'a> {
     }
 }
 
-impl DeletionResult<'_> {
+impl DeletionResult {
     pub fn to_error_string(&self) -> String {
         let mut message: String = String::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,7 @@ impl Display for OnDeleteStrategy {
 
 #[derive(Debug)]
 pub enum SpacetimeDSLError {
+    Error(String),
     NotFoundError {
         table_name: Box<str>,
         column_names_and_row_values: Box<str>,
@@ -111,6 +112,7 @@ impl Display for SpacetimeDSLError {
         let dig_spacetimedb = "Unfortunately SpacetimeDB doesn't provide more information";
 
         message.push_str(&match self {
+            SpacetimeDSLError::Error(error) => error.into(),
             SpacetimeDSLError::NotFoundError {
                 table_name,
                 column_names_and_row_values

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,17 @@ pub enum SpacetimeDSLError {
     AutoIncOverflow {
         table_name: Box<str>,
     },
-    ReferenceIntegrityViolation(DeletionResult),
+    ReferenceIntegrityViolation(ReferenceIntegrityViolationError),
+}
+
+#[derive(Debug)]
+pub enum ReferenceIntegrityViolationError {
+    OnCreateOrUpdate {
+        table_name: Box<str>,
+        create_or_update: CreateOrUpdate,
+        column_names_and_row_values: Box<str>,
+    },
+    OnDelete(DeletionResult),
 }
 
 impl Display for SpacetimeDSLError {
@@ -116,7 +126,7 @@ impl Display for SpacetimeDSLError {
             SpacetimeDSLError::NotFoundError {
                 table_name,
                 column_names_and_row_values
-            } => format!("Not Found Error while trying to find a row in the `{table_name}` table with {column_names_and_row_values}!"),
+            } => format!("Not Found Error while trying to find a row in the `{table_name}` table with `{column_names_and_row_values}`!"),
             SpacetimeDSLError::UniqueConstraintViolation {
                 table_name,
                 create_or_update,
@@ -129,8 +139,8 @@ impl Display for SpacetimeDSLError {
                 };
 
                 let column_names_and_row_values = match error_from {
-                    ErrorFrom::SpacetimeDB => format!("! {dig_spacetimedb}, so here are all columns and their values: {column_names_and_row_values}."),
-                    ErrorFrom::SpacetimeDSL => format!(" because of {column_names_and_row_values}!"),
+                    ErrorFrom::SpacetimeDB => format!("! {dig_spacetimedb}, so here are all columns and their values: `{column_names_and_row_values}`."),
+                    ErrorFrom::SpacetimeDSL => format!(" because of `{column_names_and_row_values}`!"),
                 };
 
                 format!("Unique Constraint Violation Error while trying to {create_or_update} a row in the `{table_name}` table{column_names_and_row_values}")
@@ -139,7 +149,28 @@ impl Display for SpacetimeDSLError {
                 format!("Auto Inc Overflow Error on `{table_name}` table! {dig_spacetimedb}.")
             }
             SpacetimeDSLError::ReferenceIntegrityViolation(error) => {
-                format!("Reference Integrity Violation Error: {}", error.to_error_string())
+                match error {
+                    ReferenceIntegrityViolationError::OnCreateOrUpdate {
+                        table_name,
+                        create_or_update,
+                        column_names_and_row_values
+                    } => {
+                        let create_or_update = match create_or_update {
+                            CreateOrUpdate::Create => "create",
+                            CreateOrUpdate::Update => "update",
+                        };
+
+                        format!("Reference Integrity Violation Error while trying to {create_or_update} a row in the `{table_name}` table because of `{column_names_and_row_values}`!")
+                    },
+                    ReferenceIntegrityViolationError::OnDelete(deletion_result) => {
+                        let one_or_multiple_rows = match deletion_result.one_or_multiple {
+                            OneOrMultiple::One => "a row",
+                            OneOrMultiple::Multiple => "multiple rows",
+                        };
+
+                        format!("Reference Integrity Violation Error while trying to delete {one_or_multiple_rows} in the `{}` table because of:\n\n{}", &deletion_result.table_name, deletion_result.to_csv())
+                    },
+                }
             }
         });
 
@@ -213,36 +244,13 @@ impl DeletionResultEntry {
 
 impl fmt::Display for DeletionResult {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut message = String::new();
-
-        message
-            .push_str("entry_id, parent_entry_id, table_name, column_name, strategy, row_value,\n");
-
-        let mut entry_id: u128 = 0;
-
-        for entry in &self.entries {
-            (entry_id, message) = entry.to_csv(entry_id, 0, message);
-        }
-
-        write!(f, "{}", message)
+        write!(f, "{}", self.to_csv())
     }
 }
 
 impl DeletionResult {
-    pub fn to_error_string(&self) -> String {
+    pub fn to_csv(&self) -> String {
         let mut message: String = String::new();
-
-        message.push_str("While deleting ");
-
-        match self.one_or_multiple {
-            OneOrMultiple::One => message.push_str("a row "),
-            OneOrMultiple::Multiple => message.push_str("rows "),
-        }
-
-        message.push_str(&format!(
-            "in the `{}` table, the following reference integrity violations occurred:\n\n",
-            &self.table_name
-        ));
 
         message
             .push_str("entry_id, parent_entry_id, table_name, column_name, strategy, row_value,\n");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,10 @@ pub use itertools;
 use spacetimedb::ReducerContext;
 pub use spacetimedsl_derive::{SpacetimeDSL, dsl};
 use std::collections::HashMap;
+use std::{
+    error::Error,
+    fmt::{self, Display},
+};
 
 pub struct DSL<'a> {
     pub(crate) ctx: &'a ReducerContext,
@@ -30,20 +34,57 @@ pub trait Wrapper<WrappedType: Clone + Default, WrapperType> {
 // TODO: New Feature "Soft Deletion" - if a table has a column "deleted: bool" then there is another dsl method which sets the flag to true instead of deleting the row.
 
 // Don't forget to copy + paste this enum into `derive_input::api::dsl::foreign_key` if you change it
-#[derive(Debug, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum OnDeleteStrategy {
-    /// Available independent from the column type.
+    /**
+     * Available independent from the column type.
+     * If a row of a table should be deleted whose primary key value is referenced in foreign keys of other tables ...
+     * ... the deletion fails.
+     */
     Error,
 
-    /// Available independent from the column type.
+    /**
+     * Available independent from the column type.
+     * If a row of a table should be deleted whose primary key value is referenced in foreign keys of other tables ...
+     * ... it's checked whether any primary key value of rows to delete is referenced in a foreign key with `OnDeleteStrategy::Error`.
+     * If true, the deletion fails and no other on delete strategy is executed.
+     * If false, the on delete strategies of all affected rows are executed.
+     */
     Delete,
 
-    // TODO: Because Option is currently not allowed on primary_key and unique/btree indices this strategy isn't used and implemented yet.
-    /// Available only for columns with type `Option<T>`.
+    /**
+     * TODO: Because Option is currently not allowed on primary_key and unique/btree indices this strategy isn't used and implemented yet.
+     * Available only for columns with type `Option<T>`.
+     * If a row of a table should be deleted whose primary key value is referenced in foreign keys of other tables ...
+     * ... the value of the foreign key column is set to `None`.
+     */
     //SetNone,
 
-    /// Available only for columns with a numeric type.
+    /**
+     * Available only for columns with a numeric type.
+     * If a row of a table should be deleted whose primary key value is referenced in foreign keys of other tables ...
+     * ... the value of the foreign key column is set to `0`.
+     */
     SetZero,
+
+    /**
+     * Available independent from the column type.
+     * If a row of a table should be deleted whose primary key value is referenced in foreign keys of other tables ...
+     * ... nothing happens, which means the referencing rows will reference a primary key value which doesn't exist anymore.
+     * The referential integrity is only enforced while creating a row or if a row is updated and the foreign key column value is changed.
+     */
+    Ignore,
+}
+
+impl Display for OnDeleteStrategy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OnDeleteStrategy::Error => write!(f, "Error"),
+            OnDeleteStrategy::Delete => write!(f, "Delete"),
+            OnDeleteStrategy::SetZero => write!(f, "SetZero"),
+            OnDeleteStrategy::Ignore => write!(f, "Ignore"),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,6 +183,12 @@ impl Display for SpacetimeDSLError {
 
 impl Error for SpacetimeDSLError {}
 
+impl From<SpacetimeDSLError> for String {
+    fn from(value: SpacetimeDSLError) -> Self {
+        value.to_string()
+    }
+}
+
 #[derive(Debug)]
 pub enum Action {
     Create,


### PR DESCRIPTION
Closes #36 

Breaking changes:
- Added `SpacetimeDSLError` enum with `NotFound`, `UniqueConstraintViolation`, `AutoIncOverflow` and `ReferenceIntegrityViolation` variants - all DSL methods return them now (except the `GetAll`, `Count` and `GetMany` methods).
- Added `DeletionResult` and `DeletionResultEntry`, used as return type from the `DeleteOne` and `DeleteMany` DSL method as well as in the `ReferenceIntegrityViolationError::OnDelete`. Both have a `to_csv`-method which is used to display the DeletionResult as well as the `ReferenceIntegrityViolationError::OnDelete`.

Other changes:
- Added `OnDeleteStrategy` documentation
- Added `OnDeleteStrategy::Ignore`
- Wrapper Types now implement `std::fmt::Display`
- Added `ReferenceIntegrityViolationError` enum with `OnCreateOrUpdate` and `OnDelete` variants
- Implemented `std::fmt::Display` for Wrapper Types and `SpacetimeDSLError`