### PR TITLE
Fix `<Before|After>DeleteHooks` on tables with a `#[foreign_key]` on an `#[unique]` index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,9 +209,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 dependencies = [
  "serde",
 ]
@@ -676,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8037ee5a6fa7348bf0392c728e4de4a0ba6f89c967eff80b666ac3e1e8f2b612"
+checksum = "b6eff5017248ff2e35e03564df947fdf3e963f7198be6ae1d9e894c2efb2ea15"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -699,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bindings-macro"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "202fb591c7d18fbbd4aec24a34ad6f03e3accc41580aee0fd2f9ad0514681917"
+checksum = "fce86c7657dcb42a33ce55f0100f98964dc15b64e79f06803a478676b74d6c82"
 dependencies = [
  "heck 0.4.1",
  "humantime",
@@ -713,18 +713,18 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bindings-sys"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60869317019bbc8fa571e5c8ff21fe72abf9e5bcb579531efdded4e93a76e827"
+checksum = "dbe5f9d71d59bdb93d81a7a61eee75ac2f1f88f91e139a7e263261f9dbf316de"
 dependencies = [
  "spacetimedb-primitives",
 ]
 
 [[package]]
 name = "spacetimedb-lib"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d05a4bef4619afe949f7eac9c3a31f06f21c5139c89920a8f4c7dd7b09c24a8"
+checksum = "bceaf72bdbf1a624d55d17ebaa38f8cf78a4972e43641c6cbf94f82318b5581d"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -744,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-primitives"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1e4745d32aacb71d29050f1ff6fa24fa149d939b8787f90ec28d2cac3c107b"
+checksum = "b7525fda46b21fffdc62805099dee853a79000e0673ff6df4b8355cb0b8dabe8"
 dependencies = [
  "bitflags",
  "either",
@@ -757,18 +757,18 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-query-builder"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79849bd28750b3351d54f3df4b37c5454cae3c62d0184bc9855650048a80c032"
+checksum = "1f283c4797961d9a94f623ee4c66e6a94d30861b6380a49a27ac2d9568e17125"
 dependencies = [
  "spacetimedb-lib",
 ]
 
 [[package]]
 name = "spacetimedb-sats"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ca3327e8cd735f347ef5ff08a61b9806418acdcc0394ddd35a212c0849e4295"
+checksum = "6cefb87b7d5e760d43cb65855591e25af772bdcca19562e5796ae797240d1998"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedsl"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "itertools 0.14.0",
  "spacetimedb",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedsl_blackholio"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "log",
  "spacetimedb",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedsl_derive"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "ident_case",
  "proc-macro2",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedsl_derive-input"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "ident_case",
  "itertools 0.14.0",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedsl_test"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "log",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Tamaro Skaljic<mail@tamaro-skaljic.de>"]
 name = "spacetimedsl"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2024"
 description = "The SpacetimeDB Rust Server Module meta-framework"
 documentation = "https://docs.rs/spacetimedsl"
@@ -14,10 +14,10 @@ readme = "README.md"
 
 [dependencies]
 # https://crates.io/crates/spacetimedb Easy support for interacting between SpacetimeDB and Rust.
-spacetimedb = { version = "2.6.0", features = ["unstable"] }
+spacetimedb = { version = "2.6.1", features = ["unstable"] }
 
 # https://crates.io/crates/spacetimedsl_derive Macros to extend SpacetimeDSL
-spacetimedsl_derive = { version = "0.21.0", path = "derive" }
+spacetimedsl_derive = { version = "0.21.1", path = "derive" }
 
 # https://crates.io/crates/itertools Extra iterator adaptors, iterator methods, free functions, and macros.
 itertools = "^0.14"

--- a/derive-input/Cargo.toml
+++ b/derive-input/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Tamaro Skaljic<mail@tamaro-skaljic.de>"]
 name = "spacetimedsl_derive-input"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2024"
 description = "Contains structs which represent the input and output of SpacetimeDSL. Can be used by other proc-macro crates to build Macros which utilize SpacetimeDSL under the hood."
 documentation = "https://docs.rs/spacetimedsl_derive-input"
@@ -29,7 +29,7 @@ quote = "1"
 itertools = "0.14.0"
 
 # https://crates.io/crates/spacetimedb Easy support for interacting between SpacetimeDB and Rust.
-spacetimedb = { version = "2.6.0", features = ["unstable"] }
+spacetimedb = { version = "2.6.1", features = ["unstable"] }
 
 # https://crates.io/crates/spacetime-bindings-macro-input Unofficial Input Crate for the SpacetimeDB Macro Bindings.
 spacetime-bindings-macro-input = "2.0.1"

--- a/derive-input/src/internal/dsl/method.rs
+++ b/derive-input/src/internal/dsl/method.rs
@@ -2940,9 +2940,11 @@ fn for_foreign_key(
 
         let mut error = false;
 
-        match &strategy {
-            #(#strategy_implementations)*
-        };
+        'outer: {
+            match &strategy {
+                #(#strategy_implementations)*
+            };
+        }
 
         match error {
             false => Ok(entries),
@@ -3097,7 +3099,7 @@ fn get_on_delete_strategy_implementation(
                             if crate::spacetimedsl::DSLMethodHooks::#hook_function_name(&dsl, &row).is_err() {
                                 error = true;
                                 // FIXME: This results in the error supplied by the hook being ignored, we should propagate it back to the caller but that requires changing the function signature.
-                                break;
+                                break 'outer;
                             }
                         }
                     }
@@ -3117,7 +3119,7 @@ fn get_on_delete_strategy_implementation(
                             if crate::spacetimedsl::DSLMethodHooks::#hook_function_name(&dsl, &row).is_err() {
                                 error = true;
                                 // FIXME: This results in the error supplied by the hook being ignored, we should propagate it back to the caller but that requires changing the function signature.
-                                break;
+                                break 'outer;
                             }
                         }
                     }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Tamaro Skaljic<mail@tamaro-skaljic.de>"]
 name = "spacetimedsl_derive"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2024"
 description = "Macros to extend SpacetimeDSL. You shouldn't depend on this directly and instead use the spacetimedsl crate."
 documentation = "https://docs.rs/spacetimedsl_derive"
@@ -35,4 +35,4 @@ rust-format = { version = "0.3.4", features = [
 ] }
 
 # https://crates.io/crates/spacetimedsl_derive-input Contains structs which represent the output of SpacetimeDSL. Can be used by other proc-macro crates to build Macros which utilize SpacetimeDSL under the hood.
-spacetimedsl_derive-input = { version = "0.21.0", path = "../derive-input" }
+spacetimedsl_derive-input = { version = "0.21.1", path = "../derive-input" }

--- a/examples/blackholio/Cargo.toml
+++ b/examples/blackholio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spacetimedsl_blackholio"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2024"
 publish = false
 
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # https://crates.io/crates/spacetimedb Easy support for interacting between SpacetimeDB and Rust.
-spacetimedb = { version = "2.6.0", features = ["unstable"] }
+spacetimedb = { version = "2.6.1", features = ["unstable"] }
 
 # https://crates.io/crates/spacetimedsl Ergonomic DSL for SpacetimeDB
-spacetimedsl = { version = "0.21.0", path = "../.." }
+spacetimedsl = { version = "0.21.1", path = "../.." }
 
 # https://crates.io/crates/log A lightweight logging facade for Rust
 log = "0.4"

--- a/examples/test/Cargo.toml
+++ b/examples/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spacetimedsl_test"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2024"
 publish = false
 
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 proc-macro2 = { version = "1", features = ["span-locations"] }
 
 # https://crates.io/crates/spacetimedb Easy support for interacting between SpacetimeDB and Rust.
-spacetimedb = { version = "2.6.0", features = ["unstable"] }
+spacetimedb = { version = "2.6.1", features = ["unstable"] }
 
 # https://crates.io/crates/syn Parser for Rust source code
 syn = { default-features = false, features = [
@@ -22,7 +22,7 @@ syn = { default-features = false, features = [
 ], version = "2" }
 
 # https://crates.io/crates/spacetimedsl Ergonomic DSL for SpacetimeDB
-spacetimedsl = { version = "0.21.0", path = "../.." }
+spacetimedsl = { version = "0.21.1", path = "../.." }
 
 # https://crates.io/crates/log A lightweight logging facade for Rust
 log = "0.4"

--- a/examples/test/src/lib.rs
+++ b/examples/test/src/lib.rs
@@ -1008,6 +1008,91 @@ pub mod singleton_test {
     }
 }
 
+pub mod spacetimedsl_cascade_delete_hook_repro {
+    use crate::spacetimedsl::SpacetimeDSLError;
+
+    #[spacetimedsl::dsl(plural_name = parent_records, method(update = false, delete = true))]
+    #[spacetimedb::table(accessor = parent_record)]
+    pub struct ParentRecord {
+        #[primary_key]
+        #[auto_inc]
+        #[create_wrapper(ParentRecordId)]
+        #[referenced_by(
+        path = crate::spacetimedsl_cascade_delete_hook_repro,
+        table = child_marker
+    )]
+        id: u64,
+    }
+
+    #[spacetimedsl::dsl(
+        plural_name = child_markers,
+        method(update = true, delete = true),
+        hook(before(insert, update, delete), after(insert, update, delete))
+    )]
+    #[spacetimedb::table(accessor = child_marker)]
+    pub struct ChildMarker {
+        #[primary_key]
+        #[use_wrapper(ParentRecordId)]
+        #[foreign_key(
+        path = crate::spacetimedsl_cascade_delete_hook_repro,
+        table = parent_record,
+        column = id,
+        on_delete = Delete
+    )]
+        parent_id: u64,
+    }
+
+    #[spacetimedsl::hook]
+    fn before_child_marker_insert(
+        _dsl: &crate::spacetimedsl::DSL<'_, T>,
+        row: CreateChildMarker,
+    ) -> Result<CreateChildMarker, SpacetimeDSLError> {
+        Ok(row)
+    }
+
+    #[spacetimedsl::hook]
+    fn after_child_marker_insert(
+        _dsl: &crate::spacetimedsl::DSL<'_, T>,
+        _row: &ChildMarker,
+    ) -> Result<(), SpacetimeDSLError> {
+        Ok(())
+    }
+
+    #[spacetimedsl::hook]
+    fn before_child_marker_update(
+        _dsl: &crate::spacetimedsl::DSL<'_, T>,
+        _old: &ChildMarker,
+        new: ChildMarker,
+    ) -> Result<ChildMarker, SpacetimeDSLError> {
+        Ok(new)
+    }
+
+    #[spacetimedsl::hook]
+    fn after_child_marker_update(
+        _dsl: &crate::spacetimedsl::DSL<'_, T>,
+        _old: &ChildMarker,
+        _new: &ChildMarker,
+    ) -> Result<(), SpacetimeDSLError> {
+        Ok(())
+    }
+
+    #[spacetimedsl::hook]
+    fn before_child_marker_delete(
+        _dsl: &crate::spacetimedsl::DSL<'_, T>,
+        _row: &ChildMarker,
+    ) -> Result<(), SpacetimeDSLError> {
+        Ok(())
+    }
+
+    #[spacetimedsl::hook]
+    fn after_child_marker_delete(
+        _dsl: &crate::spacetimedsl::DSL<'_, T>,
+        _row: &ChildMarker,
+    ) -> Result<(), SpacetimeDSLError> {
+        Ok(())
+    }
+}
+
 pub mod test {
     use crate::spacetimedsl::prelude::*;
     use crate::{


### PR DESCRIPTION
Also upgrade SpacetimeDB from `2.6.0` to `2.6.1` and the `ethnum` crate from `1.5.2` to `1.5.3`. Bump SpacetimeDSL version to `0.21.1`

Closes #138 